### PR TITLE
Added ScoverageKeys for coverage report

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import play.sbt.routes.RoutesKeys
+import scoverage.ScoverageKeys
 import uk.gov.hmrc.SbtArtifactory
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin.publishingSettings
 
@@ -18,6 +19,10 @@ lazy val microservice = Project(appName, file("."))
   )
   .settings(publishingSettings: _*)
   .settings(resolvers += Resolver.jcenterRepo)
+  .settings(
+    ScoverageKeys.coverageExcludedFiles := "<empty>;Reverse.*;..*Routes.*;",
+    ScoverageKeys.coverageMinimum := 80
+  )
 
 lazy val testSettings = Seq(
   unmanagedSourceDirectories   += baseDirectory.value / "test-utils",


### PR DESCRIPTION
# PAS-1067

##Bug fix

This fixes the issue that Routes should be excluded from Coverage Report. Also will fail build if coverage is less than 80%

## PR Suggestions
- Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?
- Have you done a visual check of the changes?
- Is there any still commented or unused code? Lingering printlns?
- Have things been implemented in a complicated way?
- Are the test still over the coverage threshold?
- Does the compiler throw a lot of warnings? 
- Have methods and tests been named clearly?
- Were there any changes in the config? Do changes need to be made in app-config-???


## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [ ]  I've added the links for relevant PRs for AT/PT in description

## Checklist PR Reviewer
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [ ]  I've verified the links for relevant PRs for AT/PT in description before approval