### PR TITLE
PAS-1085 Return a 400 on update if Charge Reference is invalid

### DIFF
--- a/test/controllers/DeclarationControllerSpec.scala
+++ b/test/controllers/DeclarationControllerSpec.scala
@@ -377,5 +377,16 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
         }
       }
     }
+
+    "when a request is made with an invalid charge reference" - {
+
+      "must return BAD_REQUEST" in {
+
+        val jsonPayload = Json.obj("reference" -> "XDDD0000000105", "status" -> "Successful")
+        val request = FakeRequest(POST, routes.DeclarationController.update().url).withJsonBody(jsonPayload)
+        val result = route(app, request).value
+        status(result) mustBe BAD_REQUEST
+      }
+    }
   }
 }


### PR DESCRIPTION
# PAS-1085

##Bug fix

bc-passengers-declarations service returning 500s when incorrectly formatted Charge Reference is being passed to /update. This should be a 400

## PR Suggestions
- Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?
- Have you done a visual check of the changes?
- Is there any still commented or unused code? Lingering printlns?
- Have things been implemented in a complicated way?
- Are the test still over the coverage threshold?
- Does the compiler throw a lot of warnings? 
- Have methods and tests been named clearly?
- Were there any changes in the config? Do changes need to be made in app-config-???


## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [ ]  I've added the links for relevant PRs for AT/PT in description

## Checklist PR Reviewer
 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [ ]  I've verified the links for relevant PRs for AT/PT in description before approval