### PR TITLE
PAS-1122: Remove gap between £ and amount

### DIFF
--- a/app/services/SendEmailService.scala
+++ b/app/services/SendEmailService.scala
@@ -82,7 +82,6 @@ trait SendEmailService {
     }
     val allItems: JsArray = itemsAlcohol ++ itemsTobacco ++ itemsOtherGoods
 
-
     val emailId: String = contactDetails.\("emailAddress").asOpt[String].getOrElse("")
     if (emailId.nonEmpty) {
       val firstName: String = personalDetails.\("firstName").asOpt[String].getOrElse("")
@@ -103,14 +102,14 @@ trait SendEmailService {
 
       val chargeReference: String = declarationHeader.\("chargeReference").asOpt[String].getOrElse("")
 
-      val grandTotalGBP: String = s"£ ${liabilityDetails.\("grandTotalGBP").asOpt[String].getOrElse("")}"
-      val totalExciseGBP: String = s"£ ${liabilityDetails.\("totalExciseGBP").asOpt[String].getOrElse("")}"
-      val totalCustomsGBP: String = s"£ ${liabilityDetails.\("totalCustomsGBP").asOpt[String].getOrElse("")}"
-      val totalVATGBP: String = s"£ ${liabilityDetails.\("totalVATGBP").asOpt[String].getOrElse("")}"
+      val grandTotalGBP: String = s"£${liabilityDetails.\("grandTotalGBP").asOpt[String].getOrElse("")}"
+      val totalExciseGBP: String = s"£${liabilityDetails.\("totalExciseGBP").asOpt[String].getOrElse("")}"
+      val totalCustomsGBP: String = s"£${liabilityDetails.\("totalCustomsGBP").asOpt[String].getOrElse("")}"
+      val totalVATGBP: String = s"£${liabilityDetails.\("totalVATGBP").asOpt[String].getOrElse("")}"
 
       val staticSubjectNonZero = "Receipt for payment on goods brought into the UK - Reference number "
       val staticSubjectZero = "Receipt for declaration of goods brought into Northern Ireland - Reference number "
-      val dynamicSubject = if (grandTotalGBP.equalsIgnoreCase("£ 0.00")) staticSubjectZero else staticSubjectNonZero
+      val dynamicSubject = if (grandTotalGBP.equalsIgnoreCase("£0.00")) staticSubjectZero else staticSubjectNonZero
       val subject = s"$dynamicSubject $chargeReference"
 
       val parameters: Map[String, String] = Map(
@@ -165,4 +164,5 @@ trait SendEmailService {
         Logger.error("[SendEmailServiceImpl] [sendPassengerEmail] Error in sending email")
         true
     }
+    
 }

--- a/test/services/SendEmailServiceSpec.scala
+++ b/test/services/SendEmailServiceSpec.scala
@@ -199,10 +199,10 @@ class SendEmailServiceSpec extends BaseSpec {
         "DATEOFARRIVAL" -> "10 November 2020",
         "TIMEOFARRIVAL" -> "12:16 PM",
         "REFERENCE" -> "XAPR0000001074",
-        "TOTAL" -> "£ 3,000.00",
-        "TOTALEXCISEGBP" -> "£ 1,000.00",
-        "TOTALCUSTOMSGBP" -> "£ 1,000.00",
-        "TOTALVATGBP" -> "£ 1,000.00",
+        "TOTAL" -> "£3,000.00",
+        "TOTALEXCISEGBP" -> "£1,000.00",
+        "TOTALCUSTOMSGBP" -> "£1,000.00",
+        "TOTALVATGBP" -> "£1,000.00",
         "AllITEMS" -> "")
 
     }
@@ -332,10 +332,10 @@ class SendEmailServiceSpec extends BaseSpec {
       "DATEOFARRIVAL" -> "10 November 2020",
       "TIMEOFARRIVAL" -> "12:16 PM",
       "REFERENCE" -> "XAPR0000001074",
-      "TOTAL" -> "£ 3,000.00",
-      "TOTALEXCISEGBP" -> "£ 1,000.00",
-      "TOTALCUSTOMSGBP" -> "£ 1,000.00",
-      "TOTALVATGBP" -> "£ 1,000.00",
+      "TOTAL" -> "£3,000.00",
+      "TOTALEXCISEGBP" -> "£1,000.00",
+      "TOTALCUSTOMSGBP" -> "£1,000.00",
+      "TOTALVATGBP" -> "£1,000.00",
       "AllITEMS" -> "")
 
     val testRequest = SendEmailRequest(
@@ -379,10 +379,10 @@ class SendEmailServiceSpec extends BaseSpec {
         "DATEOFARRIVAL" -> "10 November 2020",
         "TIMEOFARRIVAL" -> "12:16 PM",
         "REFERENCE" -> "XAPR0000001074",
-        "TOTAL" -> "£ 3000.00",
-        "TOTALEXCISEGBP" -> "£ 1000.00",
-        "TOTALCUSTOMSGBP" -> "£ 1000.00",
-        "TOTALVATGBP" -> "£ 1000.00",
+        "TOTAL" -> "£3000.00",
+        "TOTALEXCISEGBP" -> "£1000.00",
+        "TOTALCUSTOMSGBP" -> "£1000.00",
+        "TOTALVATGBP" -> "£1000.00",
         "AllITEMS" -> "[{\"commodityDescription\":\"Beer\",\"volume\":\"35\",\"goodsValue\":\"3254.00\",\"valueCurrency\":\"USD\",\"originCountry\":\"BQ\",\"exchangeRate\":\"1.3303\",\"exchangeRateDate\":\"2020-12-07\",\"goodsValueGBP\":\"2446.06\",\"VATRESClaimed\":false,\"exciseGBP\":\"28.00\",\"customsGBP\":\"0.00\",\"vatGBP\":\"494.81\"},{\"commodityDescription\":\"Cigarettes\",\"quantity\":\"357\",\"goodsValue\":\"753.00\",\"valueCurrency\":\"USD\",\"originCountry\":\"BQ\",\"exchangeRate\":\"1.3303\",\"exchangeRateDate\":\"2020-12-07\",\"goodsValueGBP\":\"566.03\",\"VATRESClaimed\":false,\"exciseGBP\":\"108.96\",\"customsGBP\":\"283.01\",\"vatGBP\":\"191.60\"},{\"commodityDescription\":\"Adult clothing\",\"quantity\":\"1\",\"goodsValue\":\"258.00\",\"valueCurrency\":\"USD\",\"originCountry\":\"BQ\",\"exchangeRate\":\"1.3303\",\"exchangeRateDate\":\"2020-12-07\",\"goodsValueGBP\":\"193.94\",\"VATRESClaimed\":false,\"exciseGBP\":\"0.00\",\"customsGBP\":\"0.00\",\"vatGBP\":\"0.00\"}]"
       )
       val emailParams = Map(emailService.testEmail->localTestParams)
@@ -409,10 +409,10 @@ class SendEmailServiceSpec extends BaseSpec {
            |      "DATEOFARRIVAL" : "10 November 2020",
            |      "TIMEOFARRIVAL" : "12:16 PM",
            |      "REFERENCE" : "XAPR0000001074",
-           |      "TOTAL" : "£ 3,000.00",
-           |      "TOTALEXCISEGBP" : "£ 1,000.00",
-           |      "TOTALCUSTOMSGBP" : "£ 1,000.00",
-           |      "TOTALVATGBP" : "£ 1,000.00",
+           |      "TOTAL" : "£3,000.00",
+           |      "TOTALEXCISEGBP" : "£1,000.00",
+           |      "TOTALCUSTOMSGBP" : "£1,000.00",
+           |      "TOTALVATGBP" : "£1,000.00",
            |      "AllITEMS" : ""},
            |  "force":true
            |}


### PR DESCRIPTION
# PAS-1122
## Bug fix

Remove gap between £ and amount
PR link for hmrc-email-renderer: https://github.com/hmrc/hmrc-email-renderer/pull/649

## PR Suggestions
- Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?
- Have you done a visual check of the changes?
- Is there any still commented or unused code? Lingering printlns?
- Have things been implemented in a complicated way?
- Are the test still over the coverage threshold?
- Does the compiler throw a lot of warnings? 
- Have methods and tests been named clearly?
- Were there any changes in the config? Do changes need to be made in app-config-???


## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [x]  I've added the links for relevant PRs for AT/PT in description

## Checklist PR Reviewer
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [x]  I've verified the links for relevant PRs for AT/PT in description before approval