### PR TITLE
PAS-1192 PAS-1219 Store Itemisation Flags in DB

### DIFF
--- a/conf/schemas/declarationsRequestSchema.json
+++ b/conf/schemas/declarationsRequestSchema.json
@@ -342,6 +342,18 @@
 				},
 				"originCountryName": {
 					"$ref": "#/definitions/String40"
+				},
+				"ukVATPaid": {
+					"type": "boolean"
+				},
+				"ukExcisePaid": {
+					"type": "boolean"
+				},
+				"madeIn": {
+					"$ref": "#/definitions/String40"
+				},
+				"euCustomsRelief": {
+					"type": "boolean"
 				}
 			},
 			"additionalProperties": false
@@ -390,6 +402,18 @@
 				},
 				"originCountryName": {
 					"$ref": "#/definitions/String40"
+				},
+				"ukVATPaid": {
+					"type": "boolean"
+				},
+				"uccRelief": {
+					"type": "boolean"
+				},
+				"madeIn": {
+					"$ref": "#/definitions/String40"
+				},
+				"euCustomsRelief": {
+					"type": "boolean"
 				}
 			},
 			"additionalProperties": false
@@ -456,6 +480,18 @@
 				},
 				"originCountryName": {
 					"$ref": "#/definitions/String40"
+				},
+				"ukVATPaid": {
+					"type": "boolean"
+				},
+				"ukExcisePaid": {
+					"type": "boolean"
+				},
+				"madeIn": {
+					"$ref": "#/definitions/String40"
+				},
+				"euCustomsRelief": {
+					"type": "boolean"
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
PAS-1192 and PAS-1219

Changed schema to allow Itemisation Flags to be stored in DB

https://github.com/hmrc/bc-passengers-frontend/pull/280
https://github.com/hmrc/passengers-duty-calculator/pull/56

## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [x]  I've added the links for relevant PRs for AT/PT in description

## Checklist PR Reviewer
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [x]  I've verified the links for relevant PRs for AT/PT in description before approval