### PR TITLE
PAS-1170: persist journey Data and dont send to ETMP, add tests

### DIFF
--- a/app/models/declarations/Declaration.scala
+++ b/app/models/declarations/Declaration.scala
@@ -14,6 +14,7 @@ final case class Declaration (
   chargeReference: ChargeReference,
   state: State,
   correlationId: String,
+  journeyData: JsObject,
   data: JsObject,
   lastUpdated: LocalDateTime = LocalDateTime.now
 )
@@ -28,6 +29,7 @@ object Declaration {
       (__ \ "_id").read[ChargeReference] and
       (__ \ "state").read[State] and
       (__ \ "correlationId").read[String] and
+      (__ \ "journeyData").read[JsObject] and
       (__ \ "data").read[JsObject] and
       (__ \ "lastUpdated").read[LocalDateTime]
     )(Declaration.apply _)
@@ -41,6 +43,7 @@ object Declaration {
       (__ \ "_id").write[ChargeReference] and
       (__ \ "state").write[State] and
       (__ \ "correlationId").write[String] and
+      (__ \ "journeyData").write[JsObject] and
       (__ \ "data").write[JsObject] and
       (__ \ "lastUpdated").write[LocalDateTime]
     )(unlift(Declaration.unapply))

--- a/app/repositories/DeclarationsRepository.scala
+++ b/app/repositories/DeclarationsRepository.scala
@@ -76,7 +76,8 @@ class DefaultDeclarationsRepository @Inject() (
           val declaration = Declaration(
             chargeReference = id,
             state           = State.PendingPayment,
-            data            = json,
+            journeyData     = json.apply("journeyData").as[JsObject],
+            data            = json - "journeyData",
             correlationId   = correlationId
           )
 

--- a/conf/schemas/declarationsRequestSchema.json
+++ b/conf/schemas/declarationsRequestSchema.json
@@ -3,7 +3,7 @@
 	"description": "PAS02 - Passenger Declaration Request",
 	"type": "object",
 	"minProperties": 1,
-	"maxProperties": 1,
+	"maxProperties": 2,
 	"properties": {
 		"simpleDeclarationRequest": {
 			"type": "object",
@@ -96,7 +96,7 @@
 	"required": [
 		"simpleDeclarationRequest"
 	],
-	"additionalProperties": false,
+	"additionalProperties": true,
 	"definitions": {
 		"requestCommon": {
 			"type": "object",

--- a/it/JourneySpec.scala
+++ b/it/JourneySpec.scala
@@ -30,6 +30,7 @@ class JourneySpec extends FreeSpec with MustMatchers with MongoSuite
     )
 
   val data: JsObject = Json.obj(
+    "journeyData" -> Json.obj("some" -> "journey data"),
     "simpleDeclarationRequest" -> Json.obj(
       "requestCommon" -> Json.obj(
         "receiptDate" -> "2020-12-29T12:14:08Z",

--- a/it/repositories/DeclarationsRepositorySpec.scala
+++ b/it/repositories/DeclarationsRepositorySpec.scala
@@ -25,6 +25,11 @@ class DeclarationsRepositorySpec extends FreeSpec with MustMatchers with FailOnU
     new GuiceApplicationBuilder()
 
   val inputData: JsObject = Json.obj(
+    "journeyData" -> Json.obj(
+      "euCountryCheck" -> "greatBritain",
+      "arrivingNICheck" -> true,
+      "isUKResident" -> false,
+      "bringingOverAllowance" -> true),
     "simpleDeclarationRequest" -> Json.obj(
       "requestCommon" -> Json.obj(
         "receiptDate" -> "2020-12-29T12:14:08Z",
@@ -120,6 +125,108 @@ class DeclarationsRepositorySpec extends FreeSpec with MustMatchers with FailOnU
     )
   )
 
+  val actualData: JsObject = Json.obj(
+    "simpleDeclarationRequest" -> Json.obj(
+      "requestCommon" -> Json.obj(
+        "receiptDate" -> "2020-12-29T12:14:08Z",
+        "requestParameters" -> Json.arr(
+          Json.obj(
+            "paramName" -> "REGIME",
+            "paramValue" -> "PNGR"
+          )
+        ),
+        "acknowledgementReference" -> "XMPR00000000000"
+      ),
+      "requestDetail" -> Json.obj(
+        "declarationAlcohol" -> Json.obj(
+          "totalExciseAlcohol" -> "2.00",
+          "totalCustomsAlcohol" -> "0.30",
+          "totalVATAlcohol" -> "18.70",
+          "declarationItemAlcohol" -> Json.arr(
+            Json.obj(
+              "commodityDescription" -> "Cider",
+              "volume" -> "5",
+              "goodsValue" -> "120.00",
+              "valueCurrency" -> "USD",
+              "valueCurrencyName" -> "USA dollars (USD)",
+              "originCountry" -> "US",
+              "originCountryName" -> "United States of America",
+              "exchangeRate" -> "1.20",
+              "exchangeRateDate" -> "2018-10-29",
+              "goodsValueGBP" -> "91.23",
+              "VATRESClaimed" -> false,
+              "exciseGBP" -> "2.00",
+              "customsGBP" -> "0.30",
+              "vatGBP" -> "18.70"
+            )
+          )
+        ),
+        "liabilityDetails" -> Json.obj(
+          "totalExciseGBP" -> "102.54",
+          "totalCustomsGBP" -> "534.89",
+          "totalVATGBP" -> "725.03",
+          "grandTotalGBP" -> "1362.46"
+        ),
+        "customerReference" -> Json.obj("idType" -> "passport", "idValue" -> "SX12345", "ukResident" -> false),
+        "personalDetails" -> Json.obj("firstName" -> "Harry", "lastName" -> "Potter"),
+        "declarationTobacco" -> Json.obj(
+          "totalExciseTobacco" -> "100.54",
+          "totalCustomsTobacco" -> "192.94",
+          "totalVATTobacco" -> "149.92",
+          "declarationItemTobacco" -> Json.arr(
+            Json.obj(
+              "commodityDescription" -> "Cigarettes",
+              "quantity" -> "250",
+              "goodsValue" -> "400.00",
+              "valueCurrency" -> "USD",
+              "valueCurrencyName" -> "USA dollars (USD)",
+              "originCountry" -> "US",
+              "originCountryName" -> "United States of America",
+              "exchangeRate" -> "1.20",
+              "exchangeRateDate" -> "2018-10-29",
+              "goodsValueGBP" -> "304.11",
+              "VATRESClaimed" -> false,
+              "exciseGBP" -> "74.00",
+              "customsGBP" -> "79.06",
+              "vatGBP" -> "91.43"
+            )
+          )
+        ),
+        "declarationHeader" -> Json.obj("travellingFrom" -> "NON_EU Only", "expectedDateOfArrival" -> "2018-05-31", "ukVATPaid" -> false, "uccRelief" -> false, "portOfEntryName" -> "Heathrow Airport", "ukExcisePaid" -> false, "chargeReference" -> "XMPR0000000000", "portOfEntry" -> "LHR", "timeOfEntry" -> "13:20", "onwardTravelGBNI" -> "GB", "messageTypes" -> Json.obj("messageType" -> "DeclarationCreate")),
+        "contactDetails" -> Json.obj("emailAddress" -> "abc@gmail.com"),
+        "declarationOther" -> Json.obj(
+          "totalExciseOther" -> "0.00",
+          "totalCustomsOther" -> "341.65",
+          "totalVATOther" -> "556.41",
+          "declarationItemOther" -> Json.arr(
+            Json.obj(
+              "commodityDescription" -> "Television",
+              "quantity" -> "1",
+              "goodsValue" -> "1500.00",
+              "valueCurrency" -> "USD",
+              "valueCurrencyName" -> "USA dollars (USD)",
+              "originCountry" -> "US",
+              "originCountryName" -> "United States of America",
+              "exchangeRate" -> "1.20",
+              "exchangeRateDate" -> "2018-10-29",
+              "goodsValueGBP" -> "1140.42",
+              "VATRESClaimed" -> false,
+              "exciseGBP" -> "0.00",
+              "customsGBP" -> "159.65",
+              "vatGBP" -> "260.01"
+            )
+          )
+        )
+      )
+    )
+  )
+
+  val journeyData: JsObject = Json.obj(
+    "euCountryCheck" -> "greatBritain",
+    "arrivingNICheck" -> true,
+    "isUKResident" -> false,
+    "bringingOverAllowance" -> true)
+
   "a declarations repository" - {
 
     val correlationId = "fe28db96-d9db-4220-9e12-f2d267267c29"
@@ -139,11 +246,12 @@ class DeclarationsRepositorySpec extends FreeSpec with MustMatchers with FailOnU
         val document = repository.insert(inputData, correlationId).futureValue.right.value
 
         inside(document) {
-          case Declaration(id, _, cid, data, _) =>
+          case Declaration(id, _, cid, jd, data, _) =>
 
             id mustEqual document.chargeReference
             cid mustEqual correlationId
-            data mustEqual inputData
+            jd mustEqual journeyData
+            data mustEqual actualData
         }
 
         repository.remove(document.chargeReference).futureValue
@@ -194,13 +302,13 @@ class DeclarationsRepositorySpec extends FreeSpec with MustMatchers with FailOnU
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.PendingPayment, correlationId, Json.obj(), LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(1), State.PaymentFailed, correlationId, Json.obj(), LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(2), State.PaymentCancelled, correlationId, Json.obj(), LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(3), State.Paid, correlationId, Json.obj(), LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(4), State.SubmissionFailed, correlationId, Json.obj(), LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(5), State.PendingPayment, correlationId, Json.obj(), LocalDateTime.now),
-          Declaration(ChargeReference(6), State.PendingPayment, correlationId, Json.obj(), LocalDateTime.now)
+          Declaration(ChargeReference(0), State.PendingPayment, correlationId, Json.obj(), Json.obj(), LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(1), State.PaymentFailed, correlationId, Json.obj(), Json.obj(), LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(2), State.PaymentCancelled, correlationId, Json.obj(), Json.obj(), LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(3), State.Paid, correlationId, Json.obj(), Json.obj(), LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(4), State.SubmissionFailed, correlationId, Json.obj(), Json.obj(), LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(5), State.PendingPayment, correlationId, Json.obj(), Json.obj(), LocalDateTime.now),
+          Declaration(ChargeReference(6), State.PendingPayment, correlationId, Json.obj(), Json.obj(), LocalDateTime.now)
         )
 
         database.flatMap {
@@ -251,11 +359,11 @@ class DeclarationsRepositorySpec extends FreeSpec with MustMatchers with FailOnU
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.PendingPayment, correlationId, Json.obj(), LocalDateTime.now),
-          Declaration(ChargeReference(1), State.Paid, correlationId, Json.obj(), LocalDateTime.now),
-          Declaration(ChargeReference(2), State.SubmissionFailed, correlationId, Json.obj(), LocalDateTime.now),
-          Declaration(ChargeReference(3), State.Paid, correlationId, Json.obj(), LocalDateTime.now),
-          Declaration(ChargeReference(4), State.Paid, correlationId, Json.obj(), LocalDateTime.now)
+          Declaration(ChargeReference(0), State.PendingPayment, correlationId, Json.obj(), Json.obj(), LocalDateTime.now),
+          Declaration(ChargeReference(1), State.Paid, correlationId, Json.obj(), Json.obj(), LocalDateTime.now),
+          Declaration(ChargeReference(2), State.SubmissionFailed, correlationId, Json.obj(), Json.obj(), LocalDateTime.now),
+          Declaration(ChargeReference(3), State.Paid, correlationId, Json.obj(), Json.obj(), LocalDateTime.now),
+          Declaration(ChargeReference(4), State.Paid, correlationId, Json.obj(), Json.obj(), LocalDateTime.now)
         )
 
         database.flatMap {
@@ -287,10 +395,10 @@ class DeclarationsRepositorySpec extends FreeSpec with MustMatchers with FailOnU
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, Json.obj()),
-          Declaration(ChargeReference(1), State.Paid, correlationId, Json.obj()),
-          Declaration(ChargeReference(2), State.SubmissionFailed, correlationId, Json.obj()),
-          Declaration(ChargeReference(3), State.PendingPayment, correlationId, Json.obj())
+          Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, Json.obj(), Json.obj()),
+          Declaration(ChargeReference(1), State.Paid, correlationId, Json.obj(), Json.obj()),
+          Declaration(ChargeReference(2), State.SubmissionFailed, correlationId, Json.obj(), Json.obj()),
+          Declaration(ChargeReference(3), State.PendingPayment, correlationId, Json.obj(), Json.obj())
         )
 
         database.flatMap {
@@ -339,25 +447,25 @@ class DeclarationsRepositorySpec extends FreeSpec with MustMatchers with FailOnU
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, Json.obj()),
+          Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, Json.obj(), Json.obj()),
 
-          Declaration(ChargeReference(1), State.Paid, correlationId, Json.obj()),
-          Declaration(ChargeReference(2), State.Paid, correlationId, Json.obj()),
+          Declaration(ChargeReference(1), State.Paid, correlationId, Json.obj(), Json.obj()),
+          Declaration(ChargeReference(2), State.Paid, correlationId, Json.obj(), Json.obj()),
 
-          Declaration(ChargeReference(3), State.PendingPayment, correlationId, Json.obj()),
-          Declaration(ChargeReference(4), State.PendingPayment, correlationId, Json.obj()),
-          Declaration(ChargeReference(5), State.PendingPayment, correlationId, Json.obj()),
+          Declaration(ChargeReference(3), State.PendingPayment, correlationId, Json.obj(), Json.obj()),
+          Declaration(ChargeReference(4), State.PendingPayment, correlationId, Json.obj(), Json.obj()),
+          Declaration(ChargeReference(5), State.PendingPayment, correlationId, Json.obj(), Json.obj()),
 
-          Declaration(ChargeReference(6), State.PaymentCancelled, correlationId, Json.obj()),
-          Declaration(ChargeReference(7), State.PaymentCancelled, correlationId, Json.obj()),
-          Declaration(ChargeReference(8), State.PaymentCancelled, correlationId, Json.obj()),
-          Declaration(ChargeReference(9), State.PaymentCancelled, correlationId, Json.obj()),
+          Declaration(ChargeReference(6), State.PaymentCancelled, correlationId, Json.obj(), Json.obj()),
+          Declaration(ChargeReference(7), State.PaymentCancelled, correlationId, Json.obj(), Json.obj()),
+          Declaration(ChargeReference(8), State.PaymentCancelled, correlationId, Json.obj(), Json.obj()),
+          Declaration(ChargeReference(9), State.PaymentCancelled, correlationId, Json.obj(), Json.obj()),
 
-          Declaration(ChargeReference(10), State.PaymentFailed, correlationId, Json.obj()),
-          Declaration(ChargeReference(11), State.PaymentFailed, correlationId, Json.obj()),
-          Declaration(ChargeReference(12), State.PaymentFailed, correlationId, Json.obj()),
-          Declaration(ChargeReference(13), State.PaymentFailed, correlationId, Json.obj()),
-          Declaration(ChargeReference(14), State.PaymentFailed, correlationId, Json.obj())
+          Declaration(ChargeReference(10), State.PaymentFailed, correlationId, Json.obj(), Json.obj()),
+          Declaration(ChargeReference(11), State.PaymentFailed, correlationId, Json.obj(), Json.obj()),
+          Declaration(ChargeReference(12), State.PaymentFailed, correlationId, Json.obj(), Json.obj()),
+          Declaration(ChargeReference(13), State.PaymentFailed, correlationId, Json.obj(), Json.obj()),
+          Declaration(ChargeReference(14), State.PaymentFailed, correlationId, Json.obj(), Json.obj())
 
         )
 

--- a/it/workers/DeclarationSubmissionWorkerSpec.scala
+++ b/it/workers/DeclarationSubmissionWorkerSpec.scala
@@ -133,6 +133,12 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
     )
   )
 
+  val journeyData: JsObject = Json.obj(
+    "euCountryCheck" -> "greatBritain",
+    "arrivingNICheck" -> true,
+    "isUKResident" -> false,
+    "bringingOverAllowance" -> true)
+
   "a declaration submission worker" - {
 
     val correlationId = "fe28db96-d9db-4220-9e12-f2d267267c29"
@@ -152,9 +158,9 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, data, LocalDateTime.now),
-          Declaration(ChargeReference(1), State.PendingPayment, correlationId, data, LocalDateTime.now),
-          Declaration(ChargeReference(2), State.Paid, correlationId, data, LocalDateTime.now)
+          Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, journeyData, data, LocalDateTime.now),
+          Declaration(ChargeReference(1), State.PendingPayment, correlationId, journeyData, data, LocalDateTime.now),
+          Declaration(ChargeReference(2), State.Paid, correlationId, journeyData, data, LocalDateTime.now)
         )
 
         database.flatMap {
@@ -189,10 +195,10 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.Paid, correlationId, Json.obj()),
-          Declaration(ChargeReference(1), State.Paid, correlationId, Json.obj()),
-          Declaration(ChargeReference(2), State.Paid, correlationId, Json.obj()),
-          Declaration(ChargeReference(3), State.Paid, correlationId, Json.obj())
+          Declaration(ChargeReference(0), State.Paid, correlationId, Json.obj(), Json.obj()),
+          Declaration(ChargeReference(1), State.Paid, correlationId, Json.obj(), Json.obj()),
+          Declaration(ChargeReference(2), State.Paid, correlationId, Json.obj(), Json.obj()),
+          Declaration(ChargeReference(3), State.Paid, correlationId, Json.obj(), Json.obj())
         )
 
         database.flatMap {
@@ -232,8 +238,8 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(1), State.Paid, correlationId, Json.obj(), LocalDateTime.now),
-          Declaration(ChargeReference(2), State.Paid, correlationId, Json.obj(), LocalDateTime.now)
+          Declaration(ChargeReference(1), State.Paid, correlationId, Json.obj(), Json.obj(), LocalDateTime.now),
+          Declaration(ChargeReference(2), State.Paid, correlationId, Json.obj(), Json.obj(), LocalDateTime.now)
         )
 
         database.flatMap {
@@ -268,7 +274,7 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(1), State.Paid, correlationId, Json.obj(), LocalDateTime.now)
+          Declaration(ChargeReference(1), State.Paid, correlationId, Json.obj(), Json.obj(), LocalDateTime.now)
         )
 
         database.flatMap {
@@ -305,9 +311,9 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, data, LocalDateTime.now),
-          Declaration(ChargeReference(1), State.PendingPayment, correlationId, data, LocalDateTime.now),
-          Declaration(ChargeReference(2), State.Paid, correlationId, data, LocalDateTime.now)
+          Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, journeyData, data, LocalDateTime.now),
+          Declaration(ChargeReference(1), State.PendingPayment, correlationId, journeyData, data, LocalDateTime.now),
+          Declaration(ChargeReference(2), State.Paid, correlationId, journeyData, data, LocalDateTime.now)
         )
 
         database.flatMap {
@@ -362,9 +368,9 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, Json.obj(), LocalDateTime.now),
-          Declaration(ChargeReference(1), State.PendingPayment, correlationId, Json.obj(), LocalDateTime.now),
-          Declaration(ChargeReference(2), State.Paid, correlationId, Json.obj(), LocalDateTime.now)
+          Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, Json.obj(), Json.obj(), LocalDateTime.now),
+          Declaration(ChargeReference(1), State.PendingPayment, correlationId, Json.obj(), Json.obj(), LocalDateTime.now),
+          Declaration(ChargeReference(2), State.Paid, correlationId, Json.obj(), Json.obj(), LocalDateTime.now)
         )
 
         database.flatMap {
@@ -398,9 +404,9 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, data, LocalDateTime.now),
-          Declaration(ChargeReference(1), State.PendingPayment, correlationId, data, LocalDateTime.now),
-          Declaration(ChargeReference(2), State.Paid, correlationId, data, LocalDateTime.now)
+          Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, journeyData, data, LocalDateTime.now),
+          Declaration(ChargeReference(1), State.PendingPayment, correlationId, journeyData, data, LocalDateTime.now),
+          Declaration(ChargeReference(2), State.Paid, correlationId, journeyData, data, LocalDateTime.now)
         )
 
         database.flatMap {
@@ -432,8 +438,8 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
         val worker = app.injector.instanceOf[DeclarationSubmissionWorker]
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.Paid, correlationId, Json.obj(), LocalDateTime.now),
-          Declaration(ChargeReference(1), State.Paid, correlationId, Json.obj(), LocalDateTime.now)
+          Declaration(ChargeReference(0), State.Paid, correlationId, Json.obj(), Json.obj(), LocalDateTime.now),
+          Declaration(ChargeReference(1), State.Paid, correlationId, Json.obj(), Json.obj(), LocalDateTime.now)
         )
 
         database.flatMap {
@@ -454,8 +460,8 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
       database.flatMap(_.drop()).futureValue
 
       val declarations = List(
-        Declaration(ChargeReference(0), State.Paid, correlationId, Json.obj(), LocalDateTime.now),
-        Declaration(ChargeReference(1), State.Paid, correlationId, Json.obj(), LocalDateTime.now)
+        Declaration(ChargeReference(0), State.Paid, correlationId, Json.obj(), Json.obj(), LocalDateTime.now),
+        Declaration(ChargeReference(1), State.Paid, correlationId, Json.obj(), Json.obj(), LocalDateTime.now)
       )
 
       database.flatMap {
@@ -494,7 +500,7 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
       database.flatMap {
         _.collection[JSONCollection]("declarations")
           .insert(ordered = true)
-          .one(Declaration(ChargeReference(0), State.Paid, correlationId, Json.obj()))
+          .one(Declaration(ChargeReference(0), State.Paid, correlationId, Json.obj(), Json.obj()))
       }.futureValue
 
       val reactor = new NioReactor()
@@ -524,7 +530,7 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
           database.flatMap {
             _.collection[JSONCollection]("declarations")
               .insert(ordered = true)
-              .one(Declaration(ChargeReference(1), State.Paid, correlationId, Json.obj()))
+              .one(Declaration(ChargeReference(1), State.Paid, correlationId, Json.obj(), Json.obj()))
           }.futureValue
 
           proxy.open()
@@ -558,9 +564,9 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, data, LocalDateTime.now),
-          Declaration(ChargeReference(1), State.PendingPayment, correlationId, data, LocalDateTime.now),
-          Declaration(ChargeReference(2), State.Paid, correlationId, data, LocalDateTime.now)
+          Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, journeyData, data, LocalDateTime.now),
+          Declaration(ChargeReference(1), State.PendingPayment, correlationId, journeyData, data, LocalDateTime.now),
+          Declaration(ChargeReference(2), State.Paid, correlationId, journeyData, data, LocalDateTime.now)
         )
 
         database.flatMap {

--- a/it/workers/FailedSubmissionWorkerSpec.scala
+++ b/it/workers/FailedSubmissionWorkerSpec.scala
@@ -33,9 +33,9 @@ class FailedSubmissionWorkerSpec extends FreeSpec with MustMatchers with MongoSu
       database.flatMap(_.drop()).futureValue
 
       val declarations = List(
-        Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, Json.obj()),
-        Declaration(ChargeReference(1), State.SubmissionFailed, correlationId, Json.obj()),
-        Declaration(ChargeReference(2), State.PendingPayment, correlationId, Json.obj())
+        Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, Json.obj(), Json.obj()),
+        Declaration(ChargeReference(1), State.SubmissionFailed, correlationId, Json.obj(), Json.obj()),
+        Declaration(ChargeReference(2), State.PendingPayment, correlationId, Json.obj(), Json.obj())
       )
 
       database.flatMap {
@@ -68,8 +68,8 @@ class FailedSubmissionWorkerSpec extends FreeSpec with MustMatchers with MongoSu
       database.flatMap(_.drop()).futureValue
 
       val declarations = List(
-        Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, Json.obj()),
-        Declaration(ChargeReference(1), State.SubmissionFailed, correlationId, Json.obj())
+        Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, Json.obj(), Json.obj()),
+        Declaration(ChargeReference(1), State.SubmissionFailed, correlationId, Json.obj(), Json.obj())
       )
 
       database.flatMap {
@@ -102,8 +102,8 @@ class FailedSubmissionWorkerSpec extends FreeSpec with MustMatchers with MongoSu
       database.flatMap(_.drop()).futureValue
 
       val declarations = List(
-        Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, Json.obj()),
-        Declaration(ChargeReference(1), State.SubmissionFailed, correlationId, Json.obj())
+        Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, Json.obj(), Json.obj()),
+        Declaration(ChargeReference(1), State.SubmissionFailed, correlationId, Json.obj(), Json.obj())
       )
 
       database.flatMap {
@@ -133,8 +133,8 @@ class FailedSubmissionWorkerSpec extends FreeSpec with MustMatchers with MongoSu
       database.flatMap(_.drop()).futureValue
 
       val declarations = List(
-        Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, Json.obj()),
-        Declaration(ChargeReference(1), State.SubmissionFailed, correlationId, Json.obj())
+        Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, Json.obj(), Json.obj()),
+        Declaration(ChargeReference(1), State.SubmissionFailed, correlationId, Json.obj(), Json.obj())
       )
 
       database.flatMap {
@@ -168,8 +168,8 @@ class FailedSubmissionWorkerSpec extends FreeSpec with MustMatchers with MongoSu
       database.flatMap(_.drop()).futureValue
 
       val declarations = List(
-        Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, Json.obj()),
-        Declaration(ChargeReference(1), State.SubmissionFailed, correlationId, Json.obj())
+        Declaration(ChargeReference(0), State.SubmissionFailed, correlationId, Json.obj(), Json.obj()),
+        Declaration(ChargeReference(1), State.SubmissionFailed, correlationId, Json.obj(), Json.obj())
       )
 
       database.flatMap {

--- a/it/workers/MetricsWorkerSpec.scala
+++ b/it/workers/MetricsWorkerSpec.scala
@@ -3,27 +3,23 @@ package workers
 import java.time.LocalDateTime
 
 import akka.stream.Materializer
-import akka.stream.scaladsl.Sink
-import logger.TestLoggerAppender
 import models.declarations.{Declaration, State}
 import models.{ChargeReference, DeclarationsStatus}
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FreeSpec, MustMatchers, OptionValues}
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.json.{JsObject, JsPath, Json, Reads}
+import play.api.libs.json.{JsPath, Json, Reads}
 import play.api.test.FakeRequest
 import play.api.test.Helpers.running
 import reactivemongo.play.json.collection.JSONCollection
 import suite.MongoSuite
 import utils.WireMockHelper
-import play.api.libs.json._
 import play.api.libs.json.Reads._
 import play.api.libs.functional.syntax._
 
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
 import play.api.test.Helpers._
 
 class MetricsWorkerSpec extends FreeSpec with MustMatchers with MongoSuite
@@ -55,8 +51,8 @@ class MetricsWorkerSpec extends FreeSpec with MustMatchers with MongoSuite
           .insert(ordered = true)
           .many(
             List(
-              Declaration(ChargeReference(0), State.PendingPayment, correlationId, Json.obj(), LocalDateTime.now),
-              Declaration(ChargeReference(1), State.PaymentFailed, correlationId, Json.obj(), LocalDateTime.now)
+              Declaration(ChargeReference(0), State.PendingPayment, correlationId, Json.obj(), Json.obj(), LocalDateTime.now),
+              Declaration(ChargeReference(1), State.PaymentFailed, correlationId, Json.obj(), Json.obj(), LocalDateTime.now)
             )
           )
       }.futureValue
@@ -83,9 +79,9 @@ class MetricsWorkerSpec extends FreeSpec with MustMatchers with MongoSuite
             .insert(ordered = true)
             .many(
               List(
-                Declaration(ChargeReference(2), State.Paid, correlationId, Json.obj(), LocalDateTime.now),
-                Declaration(ChargeReference(3), State.PaymentCancelled, correlationId, Json.obj(), LocalDateTime.now),
-                Declaration(ChargeReference(4), State.SubmissionFailed, correlationId, Json.obj(), LocalDateTime.now)
+                Declaration(ChargeReference(2), State.Paid, correlationId, Json.obj(), Json.obj(), LocalDateTime.now),
+                Declaration(ChargeReference(3), State.PaymentCancelled, correlationId, Json.obj(), Json.obj(), LocalDateTime.now),
+                Declaration(ChargeReference(4), State.SubmissionFailed, correlationId, Json.obj(), Json.obj(), LocalDateTime.now)
               )
             )
         }.futureValue

--- a/it/workers/PaymentTimeoutWorkerSpec.scala
+++ b/it/workers/PaymentTimeoutWorkerSpec.scala
@@ -13,7 +13,7 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FreeSpec, MustMatchers, OptionValues}
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.Json
 import play.api.test.Helpers.running
 import reactivemongo.api.Cursor
 import reactivemongo.play.json.collection._
@@ -52,11 +52,11 @@ class PaymentTimeoutWorkerSpec extends FreeSpec with MustMatchers with MongoSuit
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.PendingPayment, correlationId, Json.obj(), LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(1), State.PaymentFailed, correlationId, Json.obj(), LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(2), State.PaymentCancelled, correlationId, Json.obj(), LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(3), State.PendingPayment, correlationId, Json.obj(), LocalDateTime.now),
-          Declaration(ChargeReference(4), State.PendingPayment, correlationId, Json.obj(), LocalDateTime.now)
+          Declaration(ChargeReference(0), State.PendingPayment, correlationId, Json.obj(), Json.obj(), LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(1), State.PaymentFailed, correlationId, Json.obj(), Json.obj(), LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(2), State.PaymentCancelled, correlationId, Json.obj(), Json.obj(), LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(3), State.PendingPayment, correlationId, Json.obj(), Json.obj(), LocalDateTime.now),
+          Declaration(ChargeReference(4), State.PendingPayment, correlationId, Json.obj(), Json.obj(), LocalDateTime.now)
         )
 
         database.flatMap {
@@ -111,9 +111,9 @@ class PaymentTimeoutWorkerSpec extends FreeSpec with MustMatchers with MongoSuit
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.PendingPayment, correlationId, Json.obj(), LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(1), State.PendingPayment, correlationId, Json.obj(), LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(2), State.PendingPayment, correlationId, Json.obj(), LocalDateTime.now)
+          Declaration(ChargeReference(0), State.PendingPayment, correlationId, Json.obj(), Json.obj(), LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(1), State.PendingPayment, correlationId, Json.obj(), Json.obj(), LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(2), State.PendingPayment, correlationId, Json.obj(), Json.obj(), LocalDateTime.now)
         )
 
         database.flatMap {
@@ -144,9 +144,9 @@ class PaymentTimeoutWorkerSpec extends FreeSpec with MustMatchers with MongoSuit
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.PendingPayment, correlationId, Json.obj(), LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(1), State.PaymentFailed,  correlationId, Json.obj(), LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(2), State.PendingPayment, correlationId, Json.obj(), LocalDateTime.now)
+          Declaration(ChargeReference(0), State.PendingPayment, correlationId, Json.obj(), Json.obj(), LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(1), State.PaymentFailed,  correlationId, Json.obj(), Json.obj(), LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(2), State.PendingPayment, correlationId, Json.obj(), Json.obj(), LocalDateTime.now)
         )
 
         database.flatMap {
@@ -181,8 +181,8 @@ class PaymentTimeoutWorkerSpec extends FreeSpec with MustMatchers with MongoSuit
         val worker = app.injector.instanceOf[PaymentTimeoutWorker]
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.PendingPayment, correlationId, Json.obj(), LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(1), State.PendingPayment, correlationId, Json.obj(), LocalDateTime.now.minusMinutes(5))
+          Declaration(ChargeReference(0), State.PendingPayment, correlationId, Json.obj(), Json.obj(), LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(1), State.PendingPayment, correlationId, Json.obj(), Json.obj(), LocalDateTime.now.minusMinutes(5))
         )
 
         database.flatMap {
@@ -203,8 +203,8 @@ class PaymentTimeoutWorkerSpec extends FreeSpec with MustMatchers with MongoSuit
       database.flatMap(_.drop()).futureValue
 
       val declarations = List(
-        Declaration(ChargeReference(0), State.PaymentCancelled, correlationId, Json.obj(), LocalDateTime.now.minusMinutes(5)),
-        Declaration(ChargeReference(1), State.PaymentFailed, correlationId, Json.obj(), LocalDateTime.now.minusMinutes(5))
+        Declaration(ChargeReference(0), State.PaymentCancelled, correlationId, Json.obj(), Json.obj(), LocalDateTime.now.minusMinutes(5)),
+        Declaration(ChargeReference(1), State.PaymentFailed, correlationId, Json.obj(), Json.obj(), LocalDateTime.now.minusMinutes(5))
       )
 
       database.flatMap {
@@ -241,7 +241,7 @@ class PaymentTimeoutWorkerSpec extends FreeSpec with MustMatchers with MongoSuit
       database.flatMap {
         _.collection[JSONCollection]("declarations")
           .insert(ordered = true)
-          .one(Declaration(ChargeReference(0), State.PendingPayment, correlationId, Json.obj(), LocalDateTime.now.minusMinutes(5)))
+          .one(Declaration(ChargeReference(0), State.PendingPayment, correlationId, Json.obj(), Json.obj(), LocalDateTime.now.minusMinutes(5)))
       }.futureValue
 
       val reactor = new NioReactor()
@@ -271,7 +271,7 @@ class PaymentTimeoutWorkerSpec extends FreeSpec with MustMatchers with MongoSuit
           database.flatMap {
             _.collection[JSONCollection]("declarations")
               .insert(ordered = true)
-              .one(Declaration(ChargeReference(1), State.PendingPayment, correlationId, Json.obj(), LocalDateTime.now.minusMinutes(5)))
+              .one(Declaration(ChargeReference(1), State.PendingPayment, correlationId, Json.obj(), Json.obj(), LocalDateTime.now.minusMinutes(5)))
           }.futureValue
 
           proxy.open()

--- a/test/connectors/HODConnectorSpec.scala
+++ b/test/connectors/HODConnectorSpec.scala
@@ -37,6 +37,13 @@ class HODConnectorSpec extends FreeSpec with MustMatchers with GuiceOneAppPerSui
 
   private val correlationId = "fe28db96-d9db-4220-9e12-f2d267267c29"
 
+  val journeyData: JsObject = Json.obj(
+    "euCountryCheck" -> "greatBritain",
+    "arrivingNICheck" -> true,
+    "isUKResident" -> false,
+    "bringingOverAllowance" -> true
+  )
+
   val data: JsObject = Json.obj(
     "simpleDeclarationRequest" -> Json.obj(
       "requestCommon" -> Json.obj(
@@ -133,7 +140,7 @@ class HODConnectorSpec extends FreeSpec with MustMatchers with GuiceOneAppPerSui
     )
   )
 
-  private lazy val declaration = Declaration(ChargeReference(123), State.Paid, correlationId, data)
+  private lazy val declaration = Declaration(ChargeReference(123), State.Paid, correlationId, journeyData, data)
 
   private def stubCall: MappingBuilder =
     post(urlEqualTo("/declarations/passengerdeclaration/v1"))

--- a/test/controllers/DeclarationControllerSpec.scala
+++ b/test/controllers/DeclarationControllerSpec.scala
@@ -61,7 +61,9 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
 
           val message = Json.obj("simpleDeclarationRequest" -> Json.obj("foo" -> "bar"))
 
-          val declaration = Declaration(chargeReference, State.PendingPayment, correlationId, message)
+          val journeyData = Json.obj("foo" -> "bar")
+
+          val declaration = Declaration(chargeReference, State.PendingPayment, correlationId, journeyData, message)
 
           val request = FakeRequest(POST, routes.DeclarationController.submit().url)
             .withJsonBody(message).withHeaders("X-Correlation-ID" -> correlationId)
@@ -111,7 +113,7 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
 
         val chargeReference = ChargeReference(1234567890)
 
-        val declaration = Declaration(chargeReference, State.PendingPayment, correlationId, Json.obj())
+        val declaration = Declaration(chargeReference, State.PendingPayment, correlationId, Json.obj(), Json.obj())
 
         val request = FakeRequest(POST, routes.DeclarationController.submit().url)
           .withJsonBody(requestBody)
@@ -178,7 +180,7 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
 
           val chargeReference = ChargeReference(1234567890)
 
-          val declaration = Declaration(chargeReference, State.SubmissionFailed, correlationId, Json.obj())
+          val declaration = Declaration(chargeReference, State.SubmissionFailed, correlationId, Json.obj(), Json.obj())
 
           when(lockRepository.lock(1234567890))
             .thenReturn(Future.successful(true))
@@ -202,7 +204,7 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
 
           val chargeReference = ChargeReference(1234567890)
 
-          val declaration = Declaration(chargeReference, State.Paid, correlationId, Json.obj())
+          val declaration = Declaration(chargeReference, State.Paid, correlationId, Json.obj(), Json.obj())
 
           when(lockRepository.lock(1234567890))
             .thenReturn(Future.successful(true))
@@ -227,7 +229,7 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
 
           val chargeReference = ChargeReference(1234567890)
 
-          val declaration = Declaration(chargeReference, State.PendingPayment, correlationId, Json.obj())
+          val declaration = Declaration(chargeReference, State.PendingPayment, correlationId, Json.obj(), Json.obj())
 
           when(declarationsRepository.get(chargeReference))
             .thenReturn(Future.successful(Some(declaration)))
@@ -258,7 +260,7 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
 
           val jsonPayload = Json.obj("reference" -> ChargeReference(1234567890), "status" -> "Successful")
 
-          val declaration = Declaration(chargeReference, State.PendingPayment, correlationId, Json.obj())
+          val declaration = Declaration(chargeReference, State.PendingPayment, correlationId, Json.obj(), Json.obj())
           val updatedDeclaration = declaration copy (state = State.Paid)
 
           when(declarationsRepository.get(chargeReference))
@@ -292,7 +294,7 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
 
           val jsonPayload = Json.obj("reference" -> ChargeReference(1234567890), "status" -> "Failed")
 
-          val declaration = Declaration(chargeReference, State.PendingPayment, correlationId, Json.obj())
+          val declaration = Declaration(chargeReference, State.PendingPayment, correlationId, Json.obj(), Json.obj())
           val updatedDeclaration = declaration copy (state = State.PaymentFailed)
 
           when(declarationsRepository.get(chargeReference))
@@ -326,7 +328,7 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
 
           val jsonPayload = Json.obj("reference" -> ChargeReference(1234567890), "status" -> "Cancelled")
 
-          val declaration = Declaration(chargeReference, State.PendingPayment, correlationId, Json.obj())
+          val declaration = Declaration(chargeReference, State.PendingPayment, correlationId, Json.obj(), Json.obj())
           val updatedDeclaration = declaration copy (state = State.PaymentCancelled)
 
           when(declarationsRepository.get(chargeReference))

--- a/test/models/DeclarationSpec.scala
+++ b/test/models/DeclarationSpec.scala
@@ -25,6 +25,7 @@ class DeclarationSpec extends FreeSpec with MustMatchers {
         "_id"           -> "XHPR1234567890",
         "state"         -> State.PendingPayment,
         "correlationId" -> correlationId,
+        "journeyData"   -> Json.obj(),
         "data"          -> Json.obj(),
         "lastUpdated"   -> Json.toJson(lastUpdated)
       )
@@ -34,6 +35,7 @@ class DeclarationSpec extends FreeSpec with MustMatchers {
           ChargeReference(1234567890),
           State.PendingPayment,
           correlationId,
+          Json.obj(),
           Json.obj(),
           lastUpdated
         )
@@ -50,11 +52,12 @@ class DeclarationSpec extends FreeSpec with MustMatchers {
         "_id"           -> "XHPR1234567890",
         "state"         -> State.PendingPayment,
         "correlationId" -> correlationId,
+        "journeyData"   -> Json.obj(),
         "data"          -> Json.obj(),
         "lastUpdated"   -> Json.toJson(lastUpdated)
       )
 
-      Json.toJson(Declaration(ChargeReference(1234567890), State.PendingPayment, correlationId, Json.obj(), lastUpdated)) mustEqual json
+      Json.toJson(Declaration(ChargeReference(1234567890), State.PendingPayment, correlationId, Json.obj(), Json.obj(), lastUpdated)) mustEqual json
     }
   }
 }

--- a/test/services/SendEmailServiceSpec.scala
+++ b/test/services/SendEmailServiceSpec.scala
@@ -65,6 +65,128 @@ class SendEmailServiceSpec extends BaseSpec {
       val testEmail = "testEmail@digital.hmrc.gov.uk"
       val chargeReference:ChargeReference = ChargeReference(1234567890)
       val correlationId = "fe28db96-d9db-4220-9e12-f2d267267c29"
+      val journeyData: String =
+        """{
+          |"journeyData" : {
+          |        "euCountryCheck" : "greatBritain",
+          |        "arrivingNICheck" : true,
+          |        "isUKResident" : false,
+          |        "bringingOverAllowance" : true,
+          |        "privateCraft" : true,
+          |        "ageOver17" : true,
+          |        "selectedAliases" : [],
+          |        "purchasedProductInstances" : [
+          |            {
+          |                "path" : "other-goods/adult/adult-clothing",
+          |                "iid" : "RTZdbZ",
+          |                "country" : {
+          |                    "code" : "IN",
+          |                    "countryName" : "title.india",
+          |                    "alphaTwoCode" : "IN",
+          |                    "isEu" : false,
+          |                    "isCountry" : true,
+          |                    "countrySynonyms" : []
+          |                },
+          |                "currency" : "GBP",
+          |                "cost" : 500,
+          |                "isVatPaid" : false,
+          |                "isCustomPaid" : false,
+          |                "isUccRelief" : false
+          |            }
+          |        ],
+          |        "userInformation" : {
+          |            "firstName" : "xyx",
+          |            "lastName" : "dsfds",
+          |            "identificationType" : "passport",
+          |            "identificationNumber" : "dfgtersdf",
+          |            "emailAddress" : "",
+          |            "selectPlaceOfArrival" : "BEL",
+          |            "enterPlaceOfArrival" : "",
+          |            "dateOfArrival" : "2021-02-04",
+          |            "timeOfArrival" : "23:00:00.000"
+          |        },
+          |        "calculatorResponse" : {
+          |            "otherGoods" : {
+          |                "bands" : [
+          |                    {
+          |                        "code" : "B",
+          |                        "items" : [
+          |                            {
+          |                                "rateId" : "OGD/CLTHS/ADULT",
+          |                                "purchaseCost" : "500.00",
+          |                                "calculation" : {
+          |                                    "excise" : "0.00",
+          |                                    "customs" : "12.50",
+          |                                    "vat" : "102.50",
+          |                                    "allTax" : "115.00"
+          |                                },
+          |                                "metadata" : {
+          |                                    "description" : "Adult clothing",
+          |                                    "name" : "label.other-goods.adult.adult-clothing",
+          |                                    "cost" : "500.00",
+          |                                    "currency" : {
+          |                                        "code" : "GBP",
+          |                                        "displayName" : "title.british_pounds_gbp",
+          |                                        "currencySynonyms" : [
+          |                                            "England",
+          |                                            "Scotland",
+          |                                            "Wales",
+          |                                            "Northern Ireland",
+          |                                            "British",
+          |                                            "sterling",
+          |                                            "pound",
+          |                                            "GB"
+          |                                        ]
+          |                                    },
+          |                                    "country" : {
+          |                                        "code" : "IN",
+          |                                        "countryName" : "title.india",
+          |                                        "alphaTwoCode" : "IN",
+          |                                        "isEu" : false,
+          |                                        "isCountry" : true,
+          |                                        "countrySynonyms" : []
+          |                                    },
+          |                                    "exchangeRate" : {
+          |                                        "rate" : "1.00",
+          |                                        "date" : "2021-02-04"
+          |                                    }
+          |                                },
+          |                                "isVatPaid" : false,
+          |                                "isCustomPaid" : false,
+          |                                "isUccRelief" : false
+          |                            }
+          |                        ],
+          |                        "calculation" : {
+          |                            "excise" : "0.00",
+          |                            "customs" : "12.50",
+          |                            "vat" : "102.50",
+          |                            "allTax" : "115.00"
+          |                        }
+          |                    }
+          |                ],
+          |                "calculation" : {
+          |                    "excise" : "0.00",
+          |                    "customs" : "12.50",
+          |                    "vat" : "102.50",
+          |                    "allTax" : "115.00"
+          |                }
+          |            },
+          |            "calculation" : {
+          |                "excise" : "0.00",
+          |                "customs" : "12.50",
+          |                "vat" : "102.50",
+          |                "allTax" : "115.00"
+          |            },
+          |            "withinFreeAllowance" : false,
+          |            "limits" : {},
+          |            "isAnyItemOverAllowance" : true
+          |        },
+          |        "defaultCountry" : "IN",
+          |        "defaultOriginCountry" : "",
+          |        "defaultCurrency" : "GBP"
+          |    }
+          |}""".stripMargin
+
       val data: String =
         """{
           |        "simpleDeclarationRequest" : {
@@ -186,7 +308,7 @@ class SendEmailServiceSpec extends BaseSpec {
           |    "lastUpdated" : "2020-12-07T01:37:30.832"
           |}""".stripMargin
 
-      val declaration:Declaration = Declaration(chargeReference, State.PendingPayment, correlationId, Json.parse(data).as[JsObject])
+      val declaration:Declaration = Declaration(chargeReference, State.PendingPayment, correlationId, Json.parse(journeyData).as[JsObject], Json.parse(data).as[JsObject])
       val bfEmail: String = "borderforce@digital.hmrc.gov.uk"
       val isleOfManEmail: String = "isleofman@digital.hmrc.gov.uk"
 
@@ -450,28 +572,28 @@ class SendEmailServiceSpec extends BaseSpec {
 
   "constructAndSendEmail" should {
     "send an email for a zero pound journey when disable-zero-pound-email feature is false" in new Setup{
-      val declaration: Declaration = Declaration(emailService.chargeReference, State.PendingPayment, emailService.correlationId, Json.parse(zeroPoundsData).as[JsObject])
+      val declaration: Declaration = Declaration(emailService.chargeReference, State.PendingPayment, emailService.correlationId, Json.parse(emailService.journeyData).as[JsObject], Json.parse(zeroPoundsData).as[JsObject])
       when(mockServicesConfig.getBoolean("features.disable-zero-pound-email")).thenReturn(false)
       when(declarationsRepository.get(emailService.chargeReference)).thenReturn(Future.successful(Some(declaration)))
       emailService.constructAndSendEmail(emailService.chargeReference).futureValue shouldBe true
     }
 
     "not send an email for a zero pound journey when disable-zero-pound-email feature is true" in new Setup{
-      val declaration: Declaration = Declaration(emailService.chargeReference, State.PendingPayment, emailService.correlationId, Json.parse(zeroPoundsData).as[JsObject])
+      val declaration: Declaration = Declaration(emailService.chargeReference, State.PendingPayment, emailService.correlationId, Json.parse(emailService.journeyData).as[JsObject], Json.parse(zeroPoundsData).as[JsObject])
       when(mockServicesConfig.getBoolean("features.disable-zero-pound-email")).thenReturn(true)
       when(declarationsRepository.get(emailService.chargeReference)).thenReturn(Future.successful(Some(declaration)))
       emailService.constructAndSendEmail(emailService.chargeReference).futureValue shouldBe false
     }
 
     "send an email for a non zero pound journey when disable-zero-pound-email feature is true" in new Setup{
-      val declaration: Declaration = Declaration(emailService.chargeReference, State.PendingPayment, emailService.correlationId, Json.parse(emailService.data).as[JsObject])
+      val declaration: Declaration = Declaration(emailService.chargeReference, State.PendingPayment, emailService.correlationId, Json.parse(emailService.journeyData).as[JsObject], Json.parse(emailService.data).as[JsObject])
       when(mockServicesConfig.getBoolean("features.disable-zero-pound-email")).thenReturn(true)
       when(declarationsRepository.get(emailService.chargeReference)).thenReturn(Future.successful(Some(declaration)))
       emailService.constructAndSendEmail(emailService.chargeReference).futureValue shouldBe true
     }
 
     "send an email for a non zero pound journey when disable-zero-pound-email feature is false" in new Setup{
-      val declaration: Declaration = Declaration(emailService.chargeReference, State.PendingPayment, emailService.correlationId, Json.parse(emailService.data).as[JsObject])
+      val declaration: Declaration = Declaration(emailService.chargeReference, State.PendingPayment, emailService.correlationId, Json.parse(emailService.journeyData).as[JsObject], Json.parse(emailService.data).as[JsObject])
       when(mockServicesConfig.getBoolean("features.disable-zero-pound-email")).thenReturn(false)
       when(declarationsRepository.get(emailService.chargeReference)).thenReturn(Future.successful(Some(declaration)))
       emailService.constructAndSendEmail(emailService.chargeReference).futureValue shouldBe true

--- a/test/util/AuditingToolsSpec.scala
+++ b/test/util/AuditingToolsSpec.scala
@@ -21,13 +21,16 @@ class AuditingToolsSpec extends FreeSpec with MustMatchers with GuiceOneAppPerSu
 
       val chargeReference = ChargeReference(1234567890)
       val correlationId = "fe28db96-d9db-4220-9e12-f2d267267c29"
+      val journeyData = Json.obj(
+          "foo" -> "bar"
+        )
       val data = Json.obj(
         "simpleDeclarationRequest" -> Json.obj(
           "foo" -> "bar"
         )
       )
 
-      val declaration = Declaration(chargeReference, State.PendingPayment, correlationId, data)
+      val declaration = Declaration(chargeReference, State.PendingPayment, correlationId, journeyData, data)
 
       val declarationEvent = auditingTools.buildDeclarationSubmittedDataEvent(declaration)
 


### PR DESCRIPTION
# PAS-1170

##New feature

Storing Journey Data in the Declaration Service
No ATs/PTs

dependent frontend PR - https://github.com/hmrc/bc-passengers-frontend/pull/283

## PR Suggestions
- Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?
- Have you done a visual check of the changes?
- Is there any still commented or unused code? Lingering printlns?
- Have things been implemented in a complicated way?
- Are the test still over the coverage threshold?
- Does the compiler throw a lot of warnings? 
- Have methods and tests been named clearly?
- Were there any changes in the config? Do changes need to be made in app-config-???


## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [x]  I've added the links for relevant PRs for AT/PT in description

## Checklist PR Reviewer
 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [ ]  I've verified the links for relevant PRs for AT/PT in description before approval