### PR TITLE
PAS-1291 : Declaration is unsuccessful when Country name is too long.

### DIFF
--- a/conf/schemas/declarationsRequestSchema.json
+++ b/conf/schemas/declarationsRequestSchema.json
@@ -201,7 +201,7 @@
 					"$ref": "#/definitions/TimeType"
 				},
 				"travellingFrom": {
-					"$ref": "#/definitions/String40"
+					"$ref": "#/definitions/String60"
 				},
 				"uccRelief": {
 					"type": "boolean"
@@ -341,7 +341,7 @@
 					"$ref": "#/definitions/String40"
 				},
 				"originCountryName": {
-					"$ref": "#/definitions/String40"
+					"$ref": "#/definitions/String60"
 				},
 				"ukVATPaid": {
 					"type": "boolean"
@@ -401,7 +401,7 @@
 					"$ref": "#/definitions/String40"
 				},
 				"originCountryName": {
-					"$ref": "#/definitions/String40"
+					"$ref": "#/definitions/String60"
 				},
 				"ukVATPaid": {
 					"type": "boolean"
@@ -479,7 +479,7 @@
 					"$ref": "#/definitions/String40"
 				},
 				"originCountryName": {
-					"$ref": "#/definitions/String40"
+					"$ref": "#/definitions/String60"
 				},
 				"ukVATPaid": {
 					"type": "boolean"
@@ -515,6 +515,11 @@
 			"type": "string",
 			"minLength": 1,
 			"maxLength": 40
+		},
+		"String60": {
+			"type": "string",
+			"minLength": 1,
+			"maxLength": 60
 		},
 		"String14": {
 			"type": "string",

--- a/it/repositories/DeclarationsRepositorySpec.scala
+++ b/it/repositories/DeclarationsRepositorySpec.scala
@@ -37,8 +37,8 @@ class DeclarationsRepositorySpec extends FreeSpec with MustMatchers with FailOnU
           "iid" -> "UCLFeP",
           "country" -> Json.obj(
             "code" -> "IN",
-            "countryName" -> "title.india",
-            "alphaTwoCode" -> "IN",
+            "countryName" -> "title.south_georgia_and_the_south_sandwich_islands",
+            "alphaTwoCode" -> "GS",
             "isEu" -> false,
             "isCountry" -> true,
             "countrySynonyms" -> Json.arr()
@@ -259,8 +259,8 @@ class DeclarationsRepositorySpec extends FreeSpec with MustMatchers with FailOnU
         "iid" -> "UCLFeP",
         "country" -> Json.obj(
           "code" -> "IN",
-          "countryName" -> "title.india",
-          "alphaTwoCode" -> "IN",
+          "countryName" -> "title.south_georgia_and_the_south_sandwich_islands",
+          "alphaTwoCode" -> "GS",
           "isEu" -> false,
           "isCountry" -> true,
           "countrySynonyms" -> Json.arr()


### PR DESCRIPTION
# PAS-1291

##Bug fix - Declaration is unsuccessful when Country name is too long.

AT Link :  https://github.com/hmrc/bc-passengers-acceptance-tests/pull/206

## PR Suggestions
- Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?
- Have you done a visual check of the changes?
- Is there any still commented or unused code? Lingering printlns?
- Have things been implemented in a complicated way?
- Are the test still over the coverage threshold?
- Does the compiler throw a lot of warnings? 
- Have methods and tests been named clearly?
- Were there any changes in the config? Do changes need to be made in app-config-???


## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [x]  I've added the links for relevant PRs for AT/PT in description

## Checklist PR Reviewer
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [x]  I've verified the links for relevant PRs for AT/PT in description before approval