### PR TITLE
PAS-1309: correlationId should be sent to downstream process as uniqu…

### DIFF
--- a/app/connectors/HODConnector.scala
+++ b/app/connectors/HODConnector.scala
@@ -37,12 +37,16 @@ class HODConnector @Inject() (
 
     implicit val hc: HeaderCarrier = {
 
+      def geCorrelationId(isAmendment: Boolean) : String = {
+        if (isAmendment) declaration.amendCorrelationId.getOrElse(throw new Exception(s"AmendCorrelation Id is empty")) else declaration.correlationId
+      }
+
       HeaderCarrier()
         .withExtraHeaders(
           HeaderNames.ACCEPT -> ContentTypes.JSON,
           HeaderNames.DATE -> now,
           HeaderNames.AUTHORIZATION -> s"Bearer $bearerToken",
-          CORRELATION_ID -> declaration.correlationId,
+          CORRELATION_ID -> geCorrelationId(isAmendment),
           FORWARDED_HOST -> MDTP)
     }
 

--- a/app/models/declarations/Declaration.scala
+++ b/app/models/declarations/Declaration.scala
@@ -17,6 +17,7 @@ final case class Declaration (
   sentToEtmp: Boolean,
   amendSentToEtmp: Option[Boolean] = None,
   correlationId: String,
+  amendCorrelationId: Option[String] = None,
   journeyData: JsObject,
   data: JsObject,
   amendData: Option[JsObject] = None,
@@ -36,6 +37,7 @@ object Declaration {
       (__ \ "sentToEtmp").read[Boolean] and
       (__ \ "amendSentToEtmp").readNullable[Boolean] and
       (__ \ "correlationId").read[String] and
+      (__ \ "amendCorrelationId").readNullable[String] and
       (__ \ "journeyData").read[JsObject] and
       (__ \ "data").read[JsObject] and
       (__ \ "amendData").readNullable[JsObject] and
@@ -54,6 +56,7 @@ object Declaration {
       (__ \ "sentToEtmp").write[Boolean] and
       (__ \ "amendSentToEtmp").writeNullable[Boolean] and
       (__ \ "correlationId").write[String] and
+      (__ \ "amendCorrelationId").writeNullable[String] and
       (__ \ "journeyData").write[JsObject] and
       (__ \ "data").write[JsObject] and
       (__ \ "amendData").writeNullable[JsObject] and

--- a/app/repositories/DeclarationsRepository.scala
+++ b/app/repositories/DeclarationsRepository.scala
@@ -106,7 +106,7 @@ class DefaultDeclarationsRepository @Inject() (
         "journeyData" -> amendmentData.apply("journeyData").as[JsObject],
         "amendData" -> (amendmentData - "journeyData"),
         "lastUpdated" -> LocalDateTime.now,
-        "correlationId" -> correlationId
+        "amendCorrelationId" -> correlationId
       )
     )
       collection.flatMap {

--- a/it/workers/AmendmentSubmissionWorkerSpec.scala
+++ b/it/workers/AmendmentSubmissionWorkerSpec.scala
@@ -244,6 +244,7 @@ class AmendmentSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mong
   "an amendment submission worker" - {
 
     val correlationId = "fe28db96-d9db-4220-9e12-f2d267267c29"
+    val amendmentCorrelationId = "ge28db96-d9db-4220-9e12-f2d267267c30"
 
     "must submit paid amendments" in {
 
@@ -260,10 +261,10 @@ class AmendmentSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mong
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.SubmissionFailed, None,sentToEtmp = false, None, correlationId, journeyData, data, None,  LocalDateTime.now),
-          Declaration(ChargeReference(1), State.PendingPayment, None, sentToEtmp = false, None,correlationId, journeyData, data, None, LocalDateTime.now),
-          Declaration(ChargeReference(2), State.Paid, None,sentToEtmp = true, None, correlationId, journeyData, data, None, LocalDateTime.now),
-          Declaration(ChargeReference(3), State.Paid, Some(State.Paid),sentToEtmp = true, amendSentToEtmp = Some(false),correlationId, journeyData, data, Some(amendData), LocalDateTime.now)
+          Declaration(ChargeReference(0), State.SubmissionFailed, None,sentToEtmp = false, None, correlationId, Some(amendmentCorrelationId), journeyData, data, None,  LocalDateTime.now),
+          Declaration(ChargeReference(1), State.PendingPayment, None, sentToEtmp = false, None,correlationId, Some(amendmentCorrelationId), journeyData, data, None, LocalDateTime.now),
+          Declaration(ChargeReference(2), State.Paid, None,sentToEtmp = true, None, correlationId, Some(amendmentCorrelationId), journeyData, data, None, LocalDateTime.now),
+          Declaration(ChargeReference(3), State.Paid, Some(State.Paid),sentToEtmp = true, amendSentToEtmp = Some(false),correlationId, Some(amendmentCorrelationId), journeyData, data, Some(amendData), LocalDateTime.now)
         )
 
         database.flatMap {
@@ -276,6 +277,7 @@ class AmendmentSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mong
 
         val (declaration, response) = worker.tap.pull.futureValue.value
         declaration.chargeReference mustEqual ChargeReference(3)
+        declaration.amendCorrelationId.get mustBe amendmentCorrelationId
         response mustEqual SubmissionResponse.Submitted
       }
     }
@@ -298,10 +300,10 @@ class AmendmentSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mong
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.Paid, Some(State.Paid), sentToEtmp = true, Some(false), correlationId, Json.obj(), Json.obj(), Some(Json.obj())),
-          Declaration(ChargeReference(1), State.Paid, Some(State.Paid), sentToEtmp = true, Some(false), correlationId, Json.obj(), Json.obj(), Some(Json.obj())),
-          Declaration(ChargeReference(2), State.Paid, Some(State.Paid), sentToEtmp = true, Some(false), correlationId, Json.obj(), Json.obj(), Some(Json.obj())),
-          Declaration(ChargeReference(3), State.Paid, Some(State.Paid), sentToEtmp = true, Some(false), correlationId, Json.obj(), Json.obj(), Some(Json.obj()))
+          Declaration(ChargeReference(0), State.Paid, Some(State.Paid), sentToEtmp = true, Some(false), correlationId, Some(amendmentCorrelationId), Json.obj(), Json.obj(), Some(Json.obj())),
+          Declaration(ChargeReference(1), State.Paid, Some(State.Paid), sentToEtmp = true, Some(false), correlationId, Some(amendmentCorrelationId), Json.obj(), Json.obj(), Some(Json.obj())),
+          Declaration(ChargeReference(2), State.Paid, Some(State.Paid), sentToEtmp = true, Some(false), correlationId, Some(amendmentCorrelationId), Json.obj(), Json.obj(), Some(Json.obj())),
+          Declaration(ChargeReference(3), State.Paid, Some(State.Paid), sentToEtmp = true, Some(false), correlationId, Some(amendmentCorrelationId), Json.obj(), Json.obj(), Some(Json.obj()))
         )
 
         database.flatMap {
@@ -341,8 +343,8 @@ class AmendmentSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mong
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(1), State.Paid, Some(State.Paid), sentToEtmp = true, Some(false), correlationId, Json.obj(), Json.obj(), Some(Json.obj()), LocalDateTime.now),
-          Declaration(ChargeReference(2), State.Paid, Some(State.Paid), sentToEtmp = true, Some(false), correlationId, Json.obj(), Json.obj(), Some(Json.obj()), LocalDateTime.now)
+          Declaration(ChargeReference(1), State.Paid, Some(State.Paid), sentToEtmp = true, Some(false), correlationId, Some(amendmentCorrelationId), Json.obj(), Json.obj(), Some(Json.obj()), LocalDateTime.now),
+          Declaration(ChargeReference(2), State.Paid, Some(State.Paid), sentToEtmp = true, Some(false), correlationId, Some(amendmentCorrelationId), Json.obj(), Json.obj(), Some(Json.obj()), LocalDateTime.now)
         )
 
         database.flatMap {
@@ -377,7 +379,7 @@ class AmendmentSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mong
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(1), State.Paid, Some(State.Paid), sentToEtmp = true, Some(false), correlationId, Json.obj(), Json.obj(), Some(Json.obj()), LocalDateTime.now)
+          Declaration(ChargeReference(1), State.Paid, Some(State.Paid), sentToEtmp = true, Some(false), correlationId, Some(amendmentCorrelationId), Json.obj(), Json.obj(), Some(Json.obj()), LocalDateTime.now)
         )
 
         database.flatMap {
@@ -414,9 +416,9 @@ class AmendmentSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mong
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.Paid, Some(State.SubmissionFailed), sentToEtmp = true, Some(false), correlationId, journeyData, data, Some(amendData), LocalDateTime.now),
-          Declaration(ChargeReference(1), State.Paid, Some(State.PendingPayment), sentToEtmp = true, Some(false), correlationId, journeyData, data, Some(amendData), LocalDateTime.now),
-          Declaration(ChargeReference(2), State.Paid, Some(State.Paid), sentToEtmp = true, Some(false), correlationId, journeyData, data, Some(amendData), LocalDateTime.now)
+          Declaration(ChargeReference(0), State.Paid, Some(State.SubmissionFailed), sentToEtmp = true, Some(false), correlationId, Some(amendmentCorrelationId), journeyData, data, Some(amendData), LocalDateTime.now),
+          Declaration(ChargeReference(1), State.Paid, Some(State.PendingPayment), sentToEtmp = true, Some(false), correlationId, Some(amendmentCorrelationId), journeyData, data, Some(amendData), LocalDateTime.now),
+          Declaration(ChargeReference(2), State.Paid, Some(State.Paid), sentToEtmp = true, Some(false), correlationId, Some(amendmentCorrelationId), journeyData, data, Some(amendData), LocalDateTime.now)
         )
 
         database.flatMap {
@@ -471,9 +473,9 @@ class AmendmentSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mong
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.Paid, Some(State.SubmissionFailed), sentToEtmp = true, Some(false),correlationId, Json.obj(), Json.obj(), Some(Json.obj()), LocalDateTime.now),
-          Declaration(ChargeReference(1), State.Paid, Some(State.PendingPayment), sentToEtmp = true, Some(false),correlationId, Json.obj(), Json.obj(), Some(Json.obj()), LocalDateTime.now),
-          Declaration(ChargeReference(2), State.Paid, Some(State.Paid),sentToEtmp = true, Some(false),correlationId, Json.obj(), Json.obj(), Some(Json.obj()), LocalDateTime.now)
+          Declaration(ChargeReference(0), State.Paid, Some(State.SubmissionFailed), sentToEtmp = true, Some(false),correlationId, Some(amendmentCorrelationId), Json.obj(), Json.obj(), Some(Json.obj()), LocalDateTime.now),
+          Declaration(ChargeReference(1), State.Paid, Some(State.PendingPayment), sentToEtmp = true, Some(false),correlationId, Some(amendmentCorrelationId), Json.obj(), Json.obj(), Some(Json.obj()), LocalDateTime.now),
+          Declaration(ChargeReference(2), State.Paid, Some(State.Paid),sentToEtmp = true, Some(false),correlationId, Some(amendmentCorrelationId), Json.obj(), Json.obj(), Some(Json.obj()), LocalDateTime.now)
         )
 
         database.flatMap {
@@ -507,9 +509,9 @@ class AmendmentSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mong
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.Paid, Some(State.SubmissionFailed), sentToEtmp = true, Some(false),correlationId, journeyData, data, Some(amendData), LocalDateTime.now),
-          Declaration(ChargeReference(1), State.Paid, Some(State.PendingPayment), sentToEtmp = true, Some(false),correlationId, journeyData, data, Some(amendData), LocalDateTime.now),
-          Declaration(ChargeReference(2), State.Paid, Some(State.Paid), sentToEtmp = true, Some(false),correlationId, journeyData, data, Some(amendData), LocalDateTime.now),
+          Declaration(ChargeReference(0), State.Paid, Some(State.SubmissionFailed), sentToEtmp = true, Some(false),correlationId, Some(amendmentCorrelationId), journeyData, data, Some(amendData), LocalDateTime.now),
+          Declaration(ChargeReference(1), State.Paid, Some(State.PendingPayment), sentToEtmp = true, Some(false),correlationId, Some(amendmentCorrelationId), journeyData, data, Some(amendData), LocalDateTime.now),
+          Declaration(ChargeReference(2), State.Paid, Some(State.Paid), sentToEtmp = true, Some(false),correlationId, Some(amendmentCorrelationId), journeyData, data, Some(amendData), LocalDateTime.now),
         )
 
         database.flatMap {
@@ -524,7 +526,7 @@ class AmendmentSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mong
         val (declaration, result) = worker.tap.pull.futureValue.value
         result mustEqual SubmissionResponse.Failed
 
-        repository.get(declaration.chargeReference).futureValue.value.amendState mustEqual Some(State.SubmissionFailed)
+        repository.get(declaration.chargeReference).futureValue.value.amendState.get mustBe State.SubmissionFailed
       }
     }
 
@@ -541,8 +543,8 @@ class AmendmentSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mong
         val worker = app.injector.instanceOf[AmendmentSubmissionWorker]
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.Paid, Some(State.Paid),sentToEtmp = true, Some(false),correlationId, Json.obj(), Json.obj(), Some(Json.obj()), LocalDateTime.now),
-          Declaration(ChargeReference(1), State.Paid, Some(State.Paid),sentToEtmp = true, Some(false),correlationId, Json.obj(), Json.obj(), Some(Json.obj()), LocalDateTime.now)
+          Declaration(ChargeReference(0), State.Paid, Some(State.Paid),sentToEtmp = true, Some(false),correlationId, Some(amendmentCorrelationId), Json.obj(), Json.obj(), Some(Json.obj()), LocalDateTime.now),
+          Declaration(ChargeReference(1), State.Paid, Some(State.Paid),sentToEtmp = true, Some(false),correlationId, Some(amendmentCorrelationId), Json.obj(), Json.obj(), Some(Json.obj()), LocalDateTime.now)
         )
 
         database.flatMap {
@@ -563,8 +565,8 @@ class AmendmentSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mong
       database.flatMap(_.drop()).futureValue
 
       val declarations = List(
-        Declaration(ChargeReference(0), State.Paid, Some(State.Paid),sentToEtmp = true, Some(false),correlationId, Json.obj(), Json.obj(), Some(Json.obj()), LocalDateTime.now),
-        Declaration(ChargeReference(1), State.Paid, Some(State.Paid),sentToEtmp = true, Some(false),correlationId, Json.obj(), Json.obj(), Some(Json.obj()), LocalDateTime.now)
+        Declaration(ChargeReference(0), State.Paid, Some(State.Paid),sentToEtmp = true, Some(false),correlationId, Some(amendmentCorrelationId), Json.obj(), Json.obj(), Some(Json.obj()), LocalDateTime.now),
+        Declaration(ChargeReference(1), State.Paid, Some(State.Paid),sentToEtmp = true, Some(false),correlationId, Some(amendmentCorrelationId), Json.obj(), Json.obj(), Some(Json.obj()), LocalDateTime.now)
       )
 
       database.flatMap {
@@ -606,7 +608,7 @@ class AmendmentSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mong
       database.flatMap {
         _.collection[JSONCollection]("declarations")
           .insert(ordered = true)
-          .one(Declaration(ChargeReference(0), State.Paid, Some(State.Paid),sentToEtmp = true, Some(false),correlationId, journeyData, data,Some(amendData), LocalDateTime.now))
+          .one(Declaration(ChargeReference(0), State.Paid, Some(State.Paid),sentToEtmp = true, Some(false),correlationId, Some(amendmentCorrelationId), journeyData, data,Some(amendData), LocalDateTime.now))
       }.futureValue
 
       val reactor = new NioReactor()
@@ -636,7 +638,7 @@ class AmendmentSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mong
           database.flatMap {
             _.collection[JSONCollection]("declarations")
               .insert(ordered = true)
-              .one(Declaration(ChargeReference(1), State.Paid, Some(State.Paid),sentToEtmp = true, Some(false),correlationId, journeyData, data,Some(amendData), LocalDateTime.now))
+              .one(Declaration(ChargeReference(1), State.Paid, Some(State.Paid),sentToEtmp = true, Some(false),correlationId, Some(amendmentCorrelationId), journeyData, data,Some(amendData), LocalDateTime.now))
           }.futureValue
 
           proxy.open()
@@ -670,10 +672,10 @@ class AmendmentSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mong
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.Paid, Some(State.SubmissionFailed),sentToEtmp = true, Some(false),correlationId, journeyData, data, Some(amendData), LocalDateTime.now),
-          Declaration(ChargeReference(1), State.Paid, Some(State.PendingPayment),sentToEtmp = true, Some(false),correlationId, journeyData, data, Some(amendData), LocalDateTime.now),
-          Declaration(ChargeReference(2), State.Paid, None,sentToEtmp = false, None,correlationId, journeyData, data, None, LocalDateTime.now),
-          Declaration(ChargeReference(3), State.Paid, Some(State.Paid),sentToEtmp = true, amendSentToEtmp = Some(false),correlationId, journeyData, data, Some(amendData), LocalDateTime.now)
+          Declaration(ChargeReference(0), State.Paid, Some(State.SubmissionFailed),sentToEtmp = true, Some(false),correlationId, Some(amendmentCorrelationId), journeyData, data, Some(amendData), LocalDateTime.now),
+          Declaration(ChargeReference(1), State.Paid, Some(State.PendingPayment),sentToEtmp = true, Some(false),correlationId, Some(amendmentCorrelationId), journeyData, data, Some(amendData), LocalDateTime.now),
+          Declaration(ChargeReference(2), State.Paid, None,sentToEtmp = false, None,correlationId,  Some(amendmentCorrelationId), journeyData, data, None, LocalDateTime.now),
+          Declaration(ChargeReference(3), State.Paid, Some(State.Paid),sentToEtmp = true, amendSentToEtmp = Some(false),correlationId, Some(amendmentCorrelationId), journeyData, data, Some(amendData), LocalDateTime.now)
         )
 
         database.flatMap {
@@ -695,7 +697,6 @@ class AmendmentSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mong
         }
 
         result mustEqual SubmissionResponse.Submitted
-
         repository.get(declaration.chargeReference).futureValue must be(defined)
       }
     }

--- a/it/workers/DeclarationDeletionWorkerSpec.scala
+++ b/it/workers/DeclarationDeletionWorkerSpec.scala
@@ -57,9 +57,9 @@ class DeclarationDeletionWorkerSpec extends FreeSpec with MustMatchers with Mong
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.PendingPayment, None, sentToEtmp = false, None, correlationId,journeyData, Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(1), State.Paid, None, sentToEtmp = true, None, correlationId,journeyData, Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(2), State.PendingPayment, None, sentToEtmp = false, None, correlationId,journeyData, Json.obj(), None, LocalDateTime.now)
+          Declaration(ChargeReference(0), State.PendingPayment, None, sentToEtmp = false, None, correlationId, None,journeyData, Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(1), State.Paid, None, sentToEtmp = true, None, correlationId, None,journeyData, Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(2), State.PendingPayment, None, sentToEtmp = false, None, correlationId,None,journeyData, Json.obj(), None, LocalDateTime.now)
         )
 
         database.flatMap {
@@ -90,11 +90,11 @@ class DeclarationDeletionWorkerSpec extends FreeSpec with MustMatchers with Mong
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.Paid, None, sentToEtmp = true, None,correlationId, journeyData,Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(1), State.Paid, None,sentToEtmp = false, None, correlationId, journeyData,Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(2), State.Paid, None,sentToEtmp = true, None, correlationId,journeyData, Json.obj(), None, LocalDateTime.now),
-          Declaration(ChargeReference(3), State.Paid, amendState = Some(State.Paid), sentToEtmp = true, amendSentToEtmp = Some(true), correlationId,journeyData, Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(4), State.Paid, amendState = Some(State.PendingPayment), sentToEtmp = true, amendSentToEtmp = Some(false), correlationId,journeyData, Json.obj(), None, LocalDateTime.now.minusMinutes(5))
+          Declaration(ChargeReference(0), State.Paid, None, sentToEtmp = true, None,correlationId, None,journeyData,Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(1), State.Paid, None,sentToEtmp = false, None, correlationId, None,journeyData,Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(2), State.Paid, None,sentToEtmp = true, None, correlationId,None,journeyData, Json.obj(), None, LocalDateTime.now),
+          Declaration(ChargeReference(3), State.Paid, amendState = Some(State.Paid), sentToEtmp = true, amendSentToEtmp = Some(true), correlationId,None,journeyData, Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(4), State.Paid, amendState = Some(State.PendingPayment), sentToEtmp = true, amendSentToEtmp = Some(false), correlationId,None,journeyData, Json.obj(), None, LocalDateTime.now.minusMinutes(5))
         )
 
         database.flatMap {
@@ -131,10 +131,10 @@ class DeclarationDeletionWorkerSpec extends FreeSpec with MustMatchers with Mong
         val worker = app.injector.instanceOf[DeclarationDeletionWorker]
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.Paid, None,sentToEtmp = true, None, correlationId,journeyData, Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(1), State.Paid, None,sentToEtmp = true, None, correlationId,journeyData, Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(2), State.Paid, Some(State.Paid), true, Some(true), correlationId,journeyData, Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(3), State.Paid, Some(State.Paid), true, Some(false), correlationId,journeyData, Json.obj(), None, LocalDateTime.now.minusMinutes(5))
+          Declaration(ChargeReference(0), State.Paid, None,sentToEtmp = true, None, correlationId,None,journeyData, Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(1), State.Paid, None,sentToEtmp = true, None, correlationId,None,journeyData, Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(2), State.Paid, Some(State.Paid), true, Some(true), correlationId,None,journeyData, Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(3), State.Paid, Some(State.Paid), true, Some(false), correlationId,None,journeyData, Json.obj(), None, LocalDateTime.now.minusMinutes(5))
         )
 
         database.flatMap {
@@ -156,10 +156,10 @@ class DeclarationDeletionWorkerSpec extends FreeSpec with MustMatchers with Mong
       database.flatMap(_.drop()).futureValue
 
       val declarations = List(
-        Declaration(ChargeReference(0), State.Paid, None,sentToEtmp = true, None, correlationId, journeyData,Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
-        Declaration(ChargeReference(1), State.Paid, None,sentToEtmp = true, None, correlationId, journeyData,Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
-        Declaration(ChargeReference(2), State.Paid, Some(State.Paid),sentToEtmp = true, Some(true), correlationId, journeyData,Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
-        Declaration(ChargeReference(3), State.Paid, Some(State.PendingPayment),sentToEtmp = true, None, correlationId, journeyData,Json.obj(), None, LocalDateTime.now.minusMinutes(5))
+        Declaration(ChargeReference(0), State.Paid, None,sentToEtmp = true, None, correlationId, None,journeyData,Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
+        Declaration(ChargeReference(1), State.Paid, None,sentToEtmp = true, None, correlationId, None,journeyData,Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
+        Declaration(ChargeReference(2), State.Paid, Some(State.Paid),sentToEtmp = true, Some(true), correlationId, None,journeyData,Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
+        Declaration(ChargeReference(3), State.Paid, Some(State.PendingPayment),sentToEtmp = true, None, correlationId, None,journeyData,Json.obj(), None, LocalDateTime.now.minusMinutes(5))
       )
 
       database.flatMap {
@@ -197,7 +197,7 @@ class DeclarationDeletionWorkerSpec extends FreeSpec with MustMatchers with Mong
       database.flatMap {
         _.collection[JSONCollection]("declarations")
           .insert(ordered = true)
-          .one(Declaration(ChargeReference(0), State.Paid, None, sentToEtmp = true, None, correlationId,journeyData, Json.obj(), None, LocalDateTime.now.minusMinutes(5)))
+          .one(Declaration(ChargeReference(0), State.Paid, None, sentToEtmp = true, None, correlationId,None,journeyData, Json.obj(), None, LocalDateTime.now.minusMinutes(5)))
       }.futureValue
 
       val reactor = new NioReactor()
@@ -227,7 +227,7 @@ class DeclarationDeletionWorkerSpec extends FreeSpec with MustMatchers with Mong
           database.flatMap {
             _.collection[JSONCollection]("declarations")
               .insert(ordered = true)
-              .one(Declaration(ChargeReference(1), State.Paid, None, sentToEtmp = true, None, correlationId, journeyData,Json.obj(), None, LocalDateTime.now.minusMinutes(5)))
+              .one(Declaration(ChargeReference(1), State.Paid, None, sentToEtmp = true, None, correlationId, None,journeyData,Json.obj(), None, LocalDateTime.now.minusMinutes(5)))
           }.futureValue
 
           proxy.open()
@@ -239,7 +239,7 @@ class DeclarationDeletionWorkerSpec extends FreeSpec with MustMatchers with Mong
           database.flatMap {
             _.collection[JSONCollection]("declarations")
               .insert(ordered = true)
-              .one(Declaration(ChargeReference(2), State.Paid, Some(State.Paid), sentToEtmp = true, Some(true), correlationId, journeyData,Json.obj(), None, LocalDateTime.now.minusMinutes(5)))
+              .one(Declaration(ChargeReference(2), State.Paid, Some(State.Paid), sentToEtmp = true, Some(true), correlationId, None,journeyData,Json.obj(), None, LocalDateTime.now.minusMinutes(5)))
           }.futureValue
 
           proxy.open()
@@ -251,7 +251,7 @@ class DeclarationDeletionWorkerSpec extends FreeSpec with MustMatchers with Mong
           database.flatMap {
             _.collection[JSONCollection]("declarations")
               .insert(ordered = true)
-              .one(Declaration(ChargeReference(3), State.Paid, Some(State.Paid), sentToEtmp = true, Some(false), correlationId, journeyData,Json.obj(), None, LocalDateTime.now.minusMinutes(5)))
+              .one(Declaration(ChargeReference(3), State.Paid, Some(State.Paid), sentToEtmp = true, Some(false), correlationId, None,journeyData,Json.obj(), None, LocalDateTime.now.minusMinutes(5)))
           }.futureValue
 
           proxy.open()

--- a/it/workers/DeclarationSubmissionWorkerSpec.scala
+++ b/it/workers/DeclarationSubmissionWorkerSpec.scala
@@ -158,9 +158,9 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, journeyData, data, None, LocalDateTime.now),
-          Declaration(ChargeReference(1), State.PendingPayment, None, sentToEtmp = false, None, correlationId, journeyData, data, None, LocalDateTime.now),
-          Declaration(ChargeReference(2), State.Paid, None, sentToEtmp = false, None, correlationId, journeyData, data, None, LocalDateTime.now)
+          Declaration(ChargeReference(0), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, None,journeyData, data, None, LocalDateTime.now),
+          Declaration(ChargeReference(1), State.PendingPayment, None, sentToEtmp = false, None, correlationId, None,journeyData, data, None, LocalDateTime.now),
+          Declaration(ChargeReference(2), State.Paid, None, sentToEtmp = false, None, correlationId, None,journeyData, data, None, LocalDateTime.now)
         )
 
         database.flatMap {
@@ -195,10 +195,10 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.Paid, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj()),
-          Declaration(ChargeReference(1), State.Paid, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj()),
-          Declaration(ChargeReference(2), State.Paid, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj()),
-          Declaration(ChargeReference(3), State.Paid, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj())
+          Declaration(ChargeReference(0), State.Paid, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj()),
+          Declaration(ChargeReference(1), State.Paid, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj()),
+          Declaration(ChargeReference(2), State.Paid, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj()),
+          Declaration(ChargeReference(3), State.Paid, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj())
         )
 
         database.flatMap {
@@ -238,8 +238,8 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(1), State.Paid, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now),
-          Declaration(ChargeReference(2), State.Paid, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now)
+          Declaration(ChargeReference(1), State.Paid, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now),
+          Declaration(ChargeReference(2), State.Paid, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now)
         )
 
         database.flatMap {
@@ -274,7 +274,7 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(1), State.Paid, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now)
+          Declaration(ChargeReference(1), State.Paid, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now)
         )
 
         database.flatMap {
@@ -311,9 +311,9 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, journeyData, data, None, LocalDateTime.now),
-          Declaration(ChargeReference(1), State.PendingPayment, None, sentToEtmp = false, None, correlationId, journeyData, data, None, LocalDateTime.now),
-          Declaration(ChargeReference(2), State.Paid, None, sentToEtmp = false, None, correlationId, journeyData, data, None, LocalDateTime.now)
+          Declaration(ChargeReference(0), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, None,journeyData, data, None, LocalDateTime.now),
+          Declaration(ChargeReference(1), State.PendingPayment, None, sentToEtmp = false, None, correlationId, None,journeyData, data, None, LocalDateTime.now),
+          Declaration(ChargeReference(2), State.Paid, None, sentToEtmp = false, None, correlationId, None,journeyData, data, None, LocalDateTime.now)
         )
 
         database.flatMap {
@@ -368,9 +368,9 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now),
-          Declaration(ChargeReference(1), State.PendingPayment, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now),
-          Declaration(ChargeReference(2), State.Paid, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now)
+          Declaration(ChargeReference(0), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now),
+          Declaration(ChargeReference(1), State.PendingPayment, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now),
+          Declaration(ChargeReference(2), State.Paid, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now)
         )
 
         database.flatMap {
@@ -404,9 +404,9 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.SubmissionFailed, None, sentToEtmp = false,None,  correlationId, journeyData, data, None, LocalDateTime.now),
-          Declaration(ChargeReference(1), State.PendingPayment, None, sentToEtmp = false, None, correlationId, journeyData, data, None, LocalDateTime.now),
-          Declaration(ChargeReference(2), State.Paid, None, sentToEtmp = false, None, correlationId, journeyData, data, None, LocalDateTime.now)
+          Declaration(ChargeReference(0), State.SubmissionFailed, None, sentToEtmp = false,None,  correlationId, None,journeyData, data, None, LocalDateTime.now),
+          Declaration(ChargeReference(1), State.PendingPayment, None, sentToEtmp = false, None, correlationId, None,journeyData, data, None, LocalDateTime.now),
+          Declaration(ChargeReference(2), State.Paid, None, sentToEtmp = false, None, correlationId, None,journeyData, data, None, LocalDateTime.now)
         )
 
         database.flatMap {
@@ -438,8 +438,8 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
         val worker = app.injector.instanceOf[DeclarationSubmissionWorker]
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.Paid, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now),
-          Declaration(ChargeReference(1), State.Paid, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now)
+          Declaration(ChargeReference(0), State.Paid, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now),
+          Declaration(ChargeReference(1), State.Paid, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now)
         )
 
         database.flatMap {
@@ -460,8 +460,8 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
       database.flatMap(_.drop()).futureValue
 
       val declarations = List(
-        Declaration(ChargeReference(0), State.Paid, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now),
-        Declaration(ChargeReference(1), State.Paid, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now)
+        Declaration(ChargeReference(0), State.Paid, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now),
+        Declaration(ChargeReference(1), State.Paid, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now)
       )
 
       database.flatMap {
@@ -503,7 +503,7 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
       database.flatMap {
         _.collection[JSONCollection]("declarations")
           .insert(ordered = true)
-          .one(Declaration(ChargeReference(0), State.Paid, None, sentToEtmp = false, None, correlationId, journeyData, data, None, LocalDateTime.now))
+          .one(Declaration(ChargeReference(0), State.Paid, None, sentToEtmp = false, None, correlationId, None,journeyData, data, None, LocalDateTime.now))
       }.futureValue
 
       val reactor = new NioReactor()
@@ -533,7 +533,7 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
           database.flatMap {
             _.collection[JSONCollection]("declarations")
               .insert(ordered = true)
-              .one(Declaration(ChargeReference(1), State.Paid, None, sentToEtmp = false, None, correlationId, journeyData, data, None, LocalDateTime.now))
+              .one(Declaration(ChargeReference(1), State.Paid, None, sentToEtmp = false, None, correlationId, None, journeyData, data, None, LocalDateTime.now))
           }.futureValue
 
           proxy.open()
@@ -567,9 +567,9 @@ class DeclarationSubmissionWorkerSpec extends FreeSpec with MustMatchers with Mo
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, journeyData, data, None, LocalDateTime.now),
-          Declaration(ChargeReference(1), State.PendingPayment, None, sentToEtmp = false, None, correlationId, journeyData, data, None, LocalDateTime.now),
-          Declaration(ChargeReference(2), State.Paid, None, sentToEtmp = false, None, correlationId, journeyData, data, None, LocalDateTime.now)
+          Declaration(ChargeReference(0), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, None,journeyData, data, None, LocalDateTime.now),
+          Declaration(ChargeReference(1), State.PendingPayment, None, sentToEtmp = false, None, correlationId, None,journeyData, data, None, LocalDateTime.now),
+          Declaration(ChargeReference(2), State.Paid, None, sentToEtmp = false, None, correlationId, None,journeyData, data, None, LocalDateTime.now)
         )
 
         database.flatMap {

--- a/it/workers/FailedSubmissionWorkerSpec.scala
+++ b/it/workers/FailedSubmissionWorkerSpec.scala
@@ -32,9 +32,9 @@ class FailedSubmissionWorkerSpec extends FreeSpec with MustMatchers with MongoSu
       database.flatMap(_.drop()).futureValue
 
       val declarations = List(
-        Declaration(ChargeReference(0), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj()),
-        Declaration(ChargeReference(1), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj()),
-        Declaration(ChargeReference(2), State.PendingPayment, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj())
+        Declaration(ChargeReference(0), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj()),
+        Declaration(ChargeReference(1), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj()),
+        Declaration(ChargeReference(2), State.PendingPayment, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj())
       )
 
       database.flatMap {
@@ -67,8 +67,8 @@ class FailedSubmissionWorkerSpec extends FreeSpec with MustMatchers with MongoSu
       database.flatMap(_.drop()).futureValue
 
       val declarations = List(
-        Declaration(ChargeReference(0), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj()),
-        Declaration(ChargeReference(1), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj())
+        Declaration(ChargeReference(0), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj()),
+        Declaration(ChargeReference(1), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj())
       )
 
       database.flatMap {
@@ -101,8 +101,8 @@ class FailedSubmissionWorkerSpec extends FreeSpec with MustMatchers with MongoSu
       database.flatMap(_.drop()).futureValue
 
       val declarations = List(
-        Declaration(ChargeReference(0), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj()),
-        Declaration(ChargeReference(1), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj())
+        Declaration(ChargeReference(0), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj()),
+        Declaration(ChargeReference(1), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj())
       )
 
       database.flatMap {
@@ -132,8 +132,8 @@ class FailedSubmissionWorkerSpec extends FreeSpec with MustMatchers with MongoSu
       database.flatMap(_.drop()).futureValue
 
       val declarations = List(
-        Declaration(ChargeReference(0), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj()),
-        Declaration(ChargeReference(1), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj())
+        Declaration(ChargeReference(0), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj()),
+        Declaration(ChargeReference(1), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj())
       )
 
       database.flatMap {
@@ -167,8 +167,8 @@ class FailedSubmissionWorkerSpec extends FreeSpec with MustMatchers with MongoSu
       database.flatMap(_.drop()).futureValue
 
       val declarations = List(
-        Declaration(ChargeReference(0), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj()),
-        Declaration(ChargeReference(1), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj())
+        Declaration(ChargeReference(0), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, None, Json.obj(), Json.obj()),
+        Declaration(ChargeReference(1), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, None, Json.obj(), Json.obj())
       )
 
       database.flatMap {

--- a/it/workers/MetricsWorkerSpec.scala
+++ b/it/workers/MetricsWorkerSpec.scala
@@ -49,8 +49,8 @@ class MetricsWorkerSpec extends FreeSpec with MustMatchers with MongoSuite
           .insert(ordered = true)
           .many(
             List(
-              Declaration(ChargeReference(0), State.PendingPayment, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now),
-              Declaration(ChargeReference(1), State.PaymentFailed, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now)
+              Declaration(ChargeReference(0), State.PendingPayment, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now),
+              Declaration(ChargeReference(1), State.PaymentFailed, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now)
             )
           )
       }.futureValue
@@ -77,9 +77,9 @@ class MetricsWorkerSpec extends FreeSpec with MustMatchers with MongoSuite
             .insert(ordered = true)
             .many(
               List(
-                Declaration(ChargeReference(2), State.Paid, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now),
-                Declaration(ChargeReference(3), State.PaymentCancelled, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now),
-                Declaration(ChargeReference(4), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now)
+                Declaration(ChargeReference(2), State.Paid, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now),
+                Declaration(ChargeReference(3), State.PaymentCancelled, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now),
+                Declaration(ChargeReference(4), State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now)
               )
             )
         }.futureValue

--- a/it/workers/PaymentTimeoutWorkerSpec.scala
+++ b/it/workers/PaymentTimeoutWorkerSpec.scala
@@ -52,11 +52,11 @@ class PaymentTimeoutWorkerSpec extends FreeSpec with MustMatchers with MongoSuit
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.PendingPayment, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(1), State.PaymentFailed, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(2), State.PaymentCancelled, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(3), State.PendingPayment, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now),
-          Declaration(ChargeReference(4), State.PendingPayment, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now)
+          Declaration(ChargeReference(0), State.PendingPayment, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(1), State.PaymentFailed, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(2), State.PaymentCancelled, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(3), State.PendingPayment, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now),
+          Declaration(ChargeReference(4), State.PendingPayment, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now)
         )
 
         database.flatMap {
@@ -111,9 +111,9 @@ class PaymentTimeoutWorkerSpec extends FreeSpec with MustMatchers with MongoSuit
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.PendingPayment, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(1), State.PendingPayment, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(2), State.PendingPayment, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now)
+          Declaration(ChargeReference(0), State.PendingPayment, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(1), State.PendingPayment, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(2), State.PendingPayment, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now)
         )
 
         database.flatMap {
@@ -144,9 +144,9 @@ class PaymentTimeoutWorkerSpec extends FreeSpec with MustMatchers with MongoSuit
         started(app).futureValue
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.PendingPayment, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(1), State.PaymentFailed, None, sentToEtmp = false,  None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(2), State.PendingPayment, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now)
+          Declaration(ChargeReference(0), State.PendingPayment, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(1), State.PaymentFailed, None, sentToEtmp = false,  None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(2), State.PendingPayment, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now)
         )
 
         database.flatMap {
@@ -181,8 +181,8 @@ class PaymentTimeoutWorkerSpec extends FreeSpec with MustMatchers with MongoSuit
         val worker = app.injector.instanceOf[PaymentTimeoutWorker]
 
         val declarations = List(
-          Declaration(ChargeReference(0), State.PendingPayment, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
-          Declaration(ChargeReference(1), State.PendingPayment, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5))
+          Declaration(ChargeReference(0), State.PendingPayment, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
+          Declaration(ChargeReference(1), State.PendingPayment, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5))
         )
 
         database.flatMap {
@@ -203,8 +203,8 @@ class PaymentTimeoutWorkerSpec extends FreeSpec with MustMatchers with MongoSuit
       database.flatMap(_.drop()).futureValue
 
       val declarations = List(
-        Declaration(ChargeReference(0), State.PaymentCancelled, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
-        Declaration(ChargeReference(1), State.PaymentFailed, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5))
+        Declaration(ChargeReference(0), State.PaymentCancelled, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5)),
+        Declaration(ChargeReference(1), State.PaymentFailed, None, sentToEtmp = false, None, correlationId, None,Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5))
       )
 
       database.flatMap {
@@ -241,7 +241,7 @@ class PaymentTimeoutWorkerSpec extends FreeSpec with MustMatchers with MongoSuit
       database.flatMap {
         _.collection[JSONCollection]("declarations")
           .insert(ordered = true)
-          .one(Declaration(ChargeReference(0), State.PendingPayment, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5)))
+          .one(Declaration(ChargeReference(0), State.PendingPayment, None, sentToEtmp = false, None, correlationId, None, Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5)))
       }.futureValue
 
       val reactor = new NioReactor()
@@ -271,7 +271,7 @@ class PaymentTimeoutWorkerSpec extends FreeSpec with MustMatchers with MongoSuit
           database.flatMap {
             _.collection[JSONCollection]("declarations")
               .insert(ordered = true)
-              .one(Declaration(ChargeReference(1), State.PendingPayment, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5)))
+              .one(Declaration(ChargeReference(1), State.PendingPayment, None, sentToEtmp = false, None, correlationId, None, Json.obj(), Json.obj(), None, LocalDateTime.now.minusMinutes(5)))
           }.futureValue
 
           proxy.open()

--- a/test/connectors/HODConnectorSpec.scala
+++ b/test/connectors/HODConnectorSpec.scala
@@ -242,9 +242,9 @@ class HODConnectorSpec extends FreeSpec with MustMatchers with GuiceOneAppPerSui
     )
   )
 
-  private lazy val declaration = Declaration(ChargeReference(123), State.Paid, None,sentToEtmp = false, None,correlationId, journeyData, data)
+  private lazy val declaration = Declaration(ChargeReference(123), State.Paid, None,sentToEtmp = false, None,correlationId, None, journeyData, data)
 
-  private lazy val amendment = Declaration(ChargeReference(123), State.Paid, None,sentToEtmp = false, None,correlationId, journeyData, data, Some(amendData))
+  private lazy val amendment = Declaration(ChargeReference(123), State.Paid, None,sentToEtmp = false, None,correlationId, Some(correlationId), journeyData, data, Some(amendData))
 
   private def stubCall: MappingBuilder =
     post(urlEqualTo("/declarations/passengerdeclaration/v1"))

--- a/test/controllers/DeclarationControllerSpec.scala
+++ b/test/controllers/DeclarationControllerSpec.scala
@@ -63,7 +63,7 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
 
           val journeyData = Json.obj("foo" -> "bar")
 
-          val declaration = Declaration(chargeReference, State.PendingPayment, None,sentToEtmp = false, None,correlationId, journeyData, message)
+          val declaration = Declaration(chargeReference, State.PendingPayment, None,sentToEtmp = false, None,correlationId, None, journeyData, message)
 
           val request = FakeRequest(POST, routes.DeclarationController.submit().url)
             .withJsonBody(message).withHeaders("X-Correlation-ID" -> correlationId)
@@ -113,7 +113,7 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
 
         val chargeReference = ChargeReference(1234567890)
 
-        val declaration = Declaration(chargeReference, State.PendingPayment, None,sentToEtmp = false, None,correlationId, Json.obj(), Json.obj())
+        val declaration = Declaration(chargeReference, State.PendingPayment, None,sentToEtmp = false, None,correlationId, None, Json.obj(), Json.obj())
 
         val request = FakeRequest(POST, routes.DeclarationController.submit().url)
           .withJsonBody(requestBody)
@@ -329,7 +329,7 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
           val data = Json.obj("simpleDeclarationRequest" -> Json.obj("foo" -> "bar"))
 
           val amendData = inputAmendmentData - "journeyData"
-          val declaration = Declaration(chargeReference, State.PendingPayment, Some(State.PendingPayment), sentToEtmp = false, amendSentToEtmp = Some(false), correlationId, journeyData, data, Some(amendData))
+          val declaration = Declaration(chargeReference, State.PendingPayment, Some(State.PendingPayment), sentToEtmp = false, amendSentToEtmp = Some(false), correlationId, None, journeyData, data, Some(amendData))
 
           val request = FakeRequest(POST, routes.DeclarationController.submitAmendment().url)
             .withJsonBody(inputAmendmentData).withHeaders("X-Correlation-ID" -> correlationId)
@@ -382,7 +382,7 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
 
         val requestBody = Json.obj()
 
-        val declaration = Declaration(chargeReference, State.PendingPayment, Some(State.PendingPayment), sentToEtmp = false, amendSentToEtmp = Some(false), correlationId, Json.obj(), Json.obj(), Some(Json.obj()))
+        val declaration = Declaration(chargeReference, State.PendingPayment, Some(State.PendingPayment), sentToEtmp = false, amendSentToEtmp = Some(false), correlationId, None, Json.obj(), Json.obj(), Some(Json.obj()))
 
         val request = FakeRequest(POST, routes.DeclarationController.submitAmendment().url)
           .withJsonBody(requestBody)
@@ -444,7 +444,7 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
 
           val chargeReference = ChargeReference(1234567890)
 
-          val declaration = Declaration(chargeReference, State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj())
+          val declaration = Declaration(chargeReference, State.SubmissionFailed, None, sentToEtmp = false, None, correlationId, None, Json.obj(), Json.obj())
 
           when(lockRepository.lock(1234567890))
             .thenReturn(Future.successful(true))
@@ -468,7 +468,7 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
 
           val chargeReference = ChargeReference(1234567890)
 
-          val declaration = Declaration(chargeReference, State.Paid, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj())
+          val declaration = Declaration(chargeReference, State.Paid, None, sentToEtmp = false, None, correlationId, None, Json.obj(), Json.obj())
 
           when(lockRepository.lock(1234567890))
             .thenReturn(Future.successful(true))
@@ -493,7 +493,7 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
 
           val chargeReference = ChargeReference(1234567890)
 
-          val declaration = Declaration(chargeReference, State.PendingPayment, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj())
+          val declaration = Declaration(chargeReference, State.PendingPayment, None, sentToEtmp = false, None, correlationId, None, Json.obj(), Json.obj())
 
           when(declarationsRepository.get(chargeReference))
             .thenReturn(Future.successful(Some(declaration)))
@@ -524,7 +524,7 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
 
           val jsonPayload = Json.obj("reference" -> ChargeReference(1234567890), "status" -> "Successful")
 
-          val declaration = Declaration(chargeReference, State.PendingPayment, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj())
+          val declaration = Declaration(chargeReference, State.PendingPayment, None, sentToEtmp = false, None, correlationId, None, Json.obj(), Json.obj())
           val updatedDeclaration = declaration copy (state = State.Paid)
 
           when(declarationsRepository.get(chargeReference))
@@ -558,7 +558,7 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
 
           val jsonPayload = Json.obj("reference" -> ChargeReference(1234567890), "status" -> "Failed")
 
-          val declaration = Declaration(chargeReference, State.PendingPayment, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj())
+          val declaration = Declaration(chargeReference, State.PendingPayment, None, sentToEtmp = false, None, correlationId, None, Json.obj(), Json.obj())
           val updatedDeclaration = declaration copy (state = State.PaymentFailed)
 
           when(declarationsRepository.get(chargeReference))
@@ -592,7 +592,7 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
 
           val jsonPayload = Json.obj("reference" -> ChargeReference(1234567890), "status" -> "Cancelled")
 
-          val declaration = Declaration(chargeReference, State.PendingPayment, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj())
+          val declaration = Declaration(chargeReference, State.PendingPayment, None, sentToEtmp = false, None, correlationId, None, Json.obj(), Json.obj())
           val updatedDeclaration = declaration copy (state = State.PaymentCancelled)
 
           when(declarationsRepository.get(chargeReference))
@@ -671,7 +671,7 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
           val chargeReference = ChargeReference(1234567890)
 
           val amendment = Declaration(chargeReference, State.Paid, amendState = Some(State.SubmissionFailed), sentToEtmp = false,
-            amendSentToEtmp = Some(false), correlationId, Json.obj(), Json.obj(), amendData = Some(Json.obj()))
+            amendSentToEtmp = Some(false), correlationId, None, Json.obj(), Json.obj(), amendData = Some(Json.obj()))
 
           when(lockRepository.lock(1234567890))
             .thenReturn(Future.successful(true))
@@ -696,7 +696,7 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
           val chargeReference = ChargeReference(1234567890)
 
           val amendment = Declaration(chargeReference, State.Paid, amendState = Some(State.Paid), sentToEtmp = false,
-            amendSentToEtmp = Some(false), correlationId, Json.obj(), Json.obj(), amendData = Some(Json.obj()))
+            amendSentToEtmp = Some(false), correlationId, None, Json.obj(), Json.obj(), amendData = Some(Json.obj()))
 
           when(lockRepository.lock(1234567890))
             .thenReturn(Future.successful(true))
@@ -722,7 +722,7 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
           val chargeReference = ChargeReference(1234567890)
 
           val amendment = Declaration(chargeReference, State.Paid, amendState = Some(State.PendingPayment), sentToEtmp = false,
-            amendSentToEtmp = Some(false), correlationId, Json.obj(), Json.obj(), amendData = Some(Json.obj()))
+            amendSentToEtmp = Some(false), correlationId, None, Json.obj(), Json.obj(), amendData = Some(Json.obj()))
 
           when(declarationsRepository.get(chargeReference))
             .thenReturn(Future.successful(Some(amendment)))
@@ -754,7 +754,7 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
           val jsonPayload = Json.obj("reference" -> ChargeReference(1234567890), "status" -> "Successful")
 
           val amendment = Declaration(chargeReference, State.Paid, amendState = Some(State.PendingPayment), sentToEtmp = false,
-            amendSentToEtmp = Some(false), correlationId, Json.obj(), Json.obj(), amendData = Some(Json.obj()))
+            amendSentToEtmp = Some(false), correlationId, None, Json.obj(), Json.obj(), amendData = Some(Json.obj()))
           val updatedAmendment = amendment copy (amendState = Some(State.Paid))
 
           when(declarationsRepository.get(chargeReference))
@@ -789,7 +789,7 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
           val jsonPayload = Json.obj("reference" -> ChargeReference(1234567890), "status" -> "Failed")
 
           val amendment = Declaration(chargeReference, State.Paid, amendState = Some(State.PendingPayment), sentToEtmp = false,
-            amendSentToEtmp = Some(false), correlationId, Json.obj(), Json.obj(), amendData = Some(Json.obj()))
+            amendSentToEtmp = Some(false), correlationId, None, Json.obj(), Json.obj(), amendData = Some(Json.obj()))
           val updatedAmendment = amendment copy (amendState = Some(State.PaymentFailed))
 
           when(declarationsRepository.get(chargeReference))
@@ -824,7 +824,7 @@ class DeclarationControllerSpec extends FreeSpec with MustMatchers with GuiceOne
           val jsonPayload = Json.obj("reference" -> ChargeReference(1234567890), "status" -> "Cancelled")
 
           val amendment = Declaration(chargeReference, State.Paid, amendState = Some(State.PendingPayment), sentToEtmp = false,
-            amendSentToEtmp = Some(false), correlationId, Json.obj(), Json.obj(), amendData = Some(Json.obj()))
+            amendSentToEtmp = Some(false), correlationId, None, Json.obj(), Json.obj(), amendData = Some(Json.obj()))
           val updatedAmendment = amendment copy (amendState = Some(State.PaymentCancelled))
 
           when(declarationsRepository.get(chargeReference))

--- a/test/models/DeclarationSpec.scala
+++ b/test/models/DeclarationSpec.scala
@@ -39,6 +39,7 @@ class DeclarationSpec extends FreeSpec with MustMatchers {
           sentToEtmp = false,
           None,
           correlationId,
+          None,
           Json.obj(),
           Json.obj(),
           None,
@@ -63,7 +64,7 @@ class DeclarationSpec extends FreeSpec with MustMatchers {
         "lastUpdated"   -> Json.toJson(lastUpdated)
       )
 
-      Json.toJson(Declaration(ChargeReference(1234567890), State.PendingPayment, None, sentToEtmp = false, None, correlationId, Json.obj(), Json.obj(), None, lastUpdated)) mustEqual json
+      Json.toJson(Declaration(ChargeReference(1234567890), State.PendingPayment, None, sentToEtmp = false, None, correlationId, None, Json.obj(), Json.obj(), None, lastUpdated)) mustEqual json
     }
 
     "must deserialise with amendState and amendSentToEtmp" in {
@@ -92,6 +93,7 @@ class DeclarationSpec extends FreeSpec with MustMatchers {
           sentToEtmp = false,
           amendSentToEtmp = Some(false),
           correlationId,
+          None,
           Json.obj(),
           Json.obj(),
           None,
@@ -99,10 +101,11 @@ class DeclarationSpec extends FreeSpec with MustMatchers {
         )
     }
 
-    "must serialise with amendState and amendSentToEtmp" in {
+    "must serialise with amendState, amendCorrelationId and amendSentToEtmp" in {
 
       val lastUpdated = LocalDateTime.now
 
+      val amendCorrelationId = "fe28db96-d9db-4220-9e12-f2d267267c29"
       val correlationId = "fe28db96-d9db-4220-9e12-f2d267267c29"
 
 
@@ -113,12 +116,13 @@ class DeclarationSpec extends FreeSpec with MustMatchers {
         "sentToEtmp"           -> false,
         "amendSentToEtmp"      -> false,
         "correlationId"        -> correlationId,
+        "amendCorrelationId"   -> amendCorrelationId,
         "journeyData"          -> Json.obj(),
         "data"                 -> Json.obj(),
         "lastUpdated"          -> Json.toJson(lastUpdated)
       )
 
-      Json.toJson(Declaration(ChargeReference(1234567890), State.PendingPayment, Some(State.PendingPayment), sentToEtmp = false, amendSentToEtmp = Some(false), correlationId, Json.obj(), Json.obj(), None, lastUpdated)) mustEqual json
+      Json.toJson(Declaration(ChargeReference(1234567890), State.PendingPayment, Some(State.PendingPayment), sentToEtmp = false, amendSentToEtmp = Some(false), correlationId, Some(amendCorrelationId), Json.obj(), Json.obj(), None, lastUpdated)) mustEqual json
     }
   }
 }

--- a/test/services/SendEmailServiceSpec.scala
+++ b/test/services/SendEmailServiceSpec.scala
@@ -308,7 +308,7 @@ class SendEmailServiceSpec extends BaseSpec {
           |    "lastUpdated" : "2020-12-07T01:37:30.832"
           |}""".stripMargin
 
-      val declaration:Declaration = Declaration(chargeReference, State.PendingPayment, None, sentToEtmp = false, None, correlationId,Json.parse(journeyData).as[JsObject], Json.parse(data).as[JsObject])
+      val declaration:Declaration = Declaration(chargeReference, State.PendingPayment, None, sentToEtmp = false, None, correlationId, None, Json.parse(journeyData).as[JsObject], Json.parse(data).as[JsObject])
       val bfEmail: String = "borderforce@digital.hmrc.gov.uk"
       val isleOfManEmail: String = "isleofman@digital.hmrc.gov.uk"
 
@@ -576,28 +576,28 @@ class SendEmailServiceSpec extends BaseSpec {
 
   "constructAndSendEmail" should {
     "send an email for a zero pound journey when disable-zero-pound-email feature is false" in new Setup{
-      val declaration: Declaration = Declaration(emailService.chargeReference, State.PendingPayment, None, sentToEtmp = false, None, emailService.correlationId, Json.parse(emailService.journeyData).as[JsObject], Json.parse(zeroPoundsData).as[JsObject])
+      val declaration: Declaration = Declaration(emailService.chargeReference, State.PendingPayment, None, sentToEtmp = false, None, emailService.correlationId, None, Json.parse(emailService.journeyData).as[JsObject], Json.parse(zeroPoundsData).as[JsObject])
       when(mockServicesConfig.getBoolean("features.disable-zero-pound-email")).thenReturn(false)
       when(declarationsRepository.get(emailService.chargeReference)).thenReturn(Future.successful(Some(declaration)))
       emailService.constructAndSendEmail(emailService.chargeReference).futureValue shouldBe true
     }
 
     "not send an email for a zero pound journey when disable-zero-pound-email feature is true" in new Setup{
-      val declaration: Declaration = Declaration(emailService.chargeReference, State.PendingPayment, None, sentToEtmp = false, None, emailService.correlationId, Json.parse(emailService.journeyData).as[JsObject], Json.parse(zeroPoundsData).as[JsObject])
+      val declaration: Declaration = Declaration(emailService.chargeReference, State.PendingPayment, None, sentToEtmp = false, None, emailService.correlationId, None, Json.parse(emailService.journeyData).as[JsObject], Json.parse(zeroPoundsData).as[JsObject])
       when(mockServicesConfig.getBoolean("features.disable-zero-pound-email")).thenReturn(true)
       when(declarationsRepository.get(emailService.chargeReference)).thenReturn(Future.successful(Some(declaration)))
       emailService.constructAndSendEmail(emailService.chargeReference).futureValue shouldBe false
     }
 
     "send an email for a non zero pound journey when disable-zero-pound-email feature is true" in new Setup{
-      val declaration: Declaration = Declaration(emailService.chargeReference, State.PendingPayment, None, sentToEtmp = false, None, emailService.correlationId, Json.parse(emailService.journeyData).as[JsObject], Json.parse(emailService.data).as[JsObject])
+      val declaration: Declaration = Declaration(emailService.chargeReference, State.PendingPayment, None, sentToEtmp = false, None, emailService.correlationId, None, Json.parse(emailService.journeyData).as[JsObject], Json.parse(emailService.data).as[JsObject])
       when(mockServicesConfig.getBoolean("features.disable-zero-pound-email")).thenReturn(true)
       when(declarationsRepository.get(emailService.chargeReference)).thenReturn(Future.successful(Some(declaration)))
       emailService.constructAndSendEmail(emailService.chargeReference).futureValue shouldBe true
     }
 
     "send an email for a non zero pound journey when disable-zero-pound-email feature is false" in new Setup{
-      val declaration: Declaration = Declaration(emailService.chargeReference, State.PendingPayment, None, sentToEtmp = false, None, emailService.correlationId, Json.parse(emailService.journeyData).as[JsObject], Json.parse(emailService.data).as[JsObject])
+      val declaration: Declaration = Declaration(emailService.chargeReference, State.PendingPayment, None, sentToEtmp = false, None, emailService.correlationId, None, Json.parse(emailService.journeyData).as[JsObject], Json.parse(emailService.data).as[JsObject])
       when(mockServicesConfig.getBoolean("features.disable-zero-pound-email")).thenReturn(false)
       when(declarationsRepository.get(emailService.chargeReference)).thenReturn(Future.successful(Some(declaration)))
       emailService.constructAndSendEmail(emailService.chargeReference).futureValue shouldBe true

--- a/test/util/AuditingToolsSpec.scala
+++ b/test/util/AuditingToolsSpec.scala
@@ -120,7 +120,7 @@ class AuditingToolsSpec extends FreeSpec with MustMatchers with GuiceOneAppPerSu
         )
       )
 
-      val declaration = Declaration(chargeReference, State.PendingPayment, None,sentToEtmp = false, None,correlationId, journeyData, data)
+      val declaration = Declaration(chargeReference, State.PendingPayment, None,sentToEtmp = false, None,correlationId, None, journeyData, data)
 
       val declarationEvent = auditingTools.buildDeclarationSubmittedDataEvent(declaration)
 


### PR DESCRIPTION

PAS-1309

Bug fix  : correlationId should be sent to downstream process as unique id for DeclarationCreate and DeclarationAmend message types

AT Link : N/A

Please include a summary / description of the change and which issue it fixes.  Include any relevant user needs, context or links to other PRs related to this PR (eg. acceptance tests, environment config).

## PR Suggestions
- Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?
- Have you done a visual check of the changes?
- Is there any still commented or unused code? Lingering printlns?
- Have things been implemented in a complicated way?
- Are the test still over the coverage threshold?
- Does the compiler throw a lot of warnings? 
- Have methods and tests been named clearly?
- Were there any changes in the config? Do changes need to be made in app-config-???


## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [ ]  I've added the links for relevant PRs for AT/PT in description

## Checklist PR Reviewer
 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [ ]  I've verified the links for relevant PRs for AT/PT in description before approval