### PR TITLE
DDCE-4774:Updated various dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val microservice = Project(appName, file("."))
   .settings(integrationTestSettings())
   .settings(inConfig(IntegrationTest)(itSettings))
   .settings(inConfig(Test)(testSettings))
-  .settings(scalaVersion := "2.13.11")
+  .settings(scalaVersion := "2.13.12")
   .settings(
     PlayKeys.playDefaultPort := 9073,
     majorVersion := 0,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,20 +3,20 @@ import sbt.*
 object AppDependencies {
 
   private lazy val bootstrapPlayVersion = "7.19.0"
-  private lazy val hmrcMongoVersion     = "1.3.0"
+  private lazy val hmrcMongoVersion     = "1.6.0"
 
   private val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"                  %% "bootstrap-backend-play-28" % bootstrapPlayVersion,
     "com.github.java-json-tools"    % "json-schema-validator"     % "2.2.14",
     "uk.gov.hmrc.mongo"            %% "hmrc-mongo-play-28"        % hmrcMongoVersion,
-    "com.fasterxml.jackson.module" %% "jackson-module-scala"      % "2.15.2"
+    "com.fasterxml.jackson.module" %% "jackson-module-scala"      % "2.16.0"
   )
 
   private val test: Seq[ModuleID] = Seq(
-    "org.scalatest"         %% "scalatest"               % "3.2.16",
-    "com.typesafe.play"     %% "play-test"               % "2.8.20",
-    "org.mockito"           %% "mockito-scala-scalatest" % "1.17.14",
-    "com.github.tomakehurst" % "wiremock-standalone"     % "2.27.2",
+    "org.scalatest"         %% "scalatest"               % "3.2.17",
+    "com.typesafe.play"     %% "play-test"               % "2.8.21",
+    "org.mockito"           %% "mockito-scala-scalatest" % "1.17.30",
+    "com.github.tomakehurst" % "wiremock-standalone"     % "3.0.1",
     "org.scalacheck"        %% "scalacheck"              % "1.17.0",
     "uk.gov.hmrc.mongo"     %% "hmrc-mongo-test-play-28" % hmrcMongoVersion,
     "uk.gov.hmrc"           %% "bootstrap-test-play-28"  % bootstrapPlayVersion,


### PR DESCRIPTION
DDCE-4774

Updated these dependencies:

[info]   com.fasterxml.jackson.module:jackson-module-scala  : 2.15.2  -> 2.15.3  -> 2.16.0         
[info]   com.github.tomakehurst:wiremock-standalone:test,it : 2.27.2                       -> 3.0.1
[info]   com.typesafe.play:play-test:test,it                : 2.8.20  -> 2.8.21         
[info]   org.mockito:mockito-scala-scalatest:test,it        : 1.17.14 -> 1.17.30                   
[info]   org.scala-lang:scala-library                       : 2.13.11 -> 2.13.12                   
[info]   org.scalatest:scalatest:test,it                    : 3.2.16  -> 3.2.17                    
[info]   uk.gov.hmrc.mongo:hmrc-mongo-play-28               : 1.3.0              -> 1.6.0          
[info]   uk.gov.hmrc.mongo:hmrc-mongo-test-play-28:test,it  : 1.3.0              -> 1.6.0  


Did not update these as this will be done in the Play upgrade :
    
[info]   uk.gov.hmrc:bootstrap-backend-play-28              : 7.19.0             -> 7.23.0 -> 8.1.0
[info]   uk.gov.hmrc:bootstrap-test-play-28:test,it         : 7.19.0             -> 7.23.0 -> 8.1.0

